### PR TITLE
fix: DuckDB initialization when either base prefix is not empty or a non-default project id is used.    

### DIFF
--- a/src/components/TableCreate.vue
+++ b/src/components/TableCreate.vue
@@ -178,7 +178,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, toRef } from 'vue';
+import { ref, computed, watch, toRef, inject } from 'vue';
 import { useFunctions } from '@/plugins/functions';
 import { useUserStore } from '@/stores/user';
 import { useIcebergDuckDB } from '@/composables/useIcebergDuckDB';
@@ -200,9 +200,10 @@ const emit = defineEmits<{
   (e: 'created', tableName: string): void;
 }>();
 
+const config = inject<any>('appConfig', { enabledAuthentication: false });
 const functions = useFunctions();
 const userStore = useUserStore();
-const icebergDB = useIcebergDuckDB();
+const icebergDB = useIcebergDuckDB(config.baseUrlPrefix);
 const storageValidation = useStorageValidation(
   toRef(() => props.storageType),
   toRef(() => props.catalogUrl),
@@ -335,7 +336,7 @@ async function createTable() {
         SECRET iceberg_secret,
         ENDPOINT '${props.catalogUrl}'
       );
-      
+
       -- Create the table
       ${createTableSQL}
     `;

--- a/src/components/TablePreview.vue
+++ b/src/components/TablePreview.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, toRef, watch } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, toRef, watch, inject } from 'vue';
 import { useFunctions } from '@/plugins/functions';
 import { useUserStore } from '@/stores/user';
 import { useIcebergDuckDB } from '@/composables/useIcebergDuckDB';
@@ -89,9 +89,10 @@ const props = defineProps<{
   storageType?: string; // Storage type: s3, adls, gcs, etc.
 }>();
 
+const config = inject<any>('appConfig', { enabledAuthentication: false });
 const functions = useFunctions();
 const userStore = useUserStore();
-const icebergDB = useIcebergDuckDB();
+const icebergDB = useIcebergDuckDB(config.baseUrlPrefix);
 const csvDownload = useCsvDownload();
 
 const storageValidation = useStorageValidation(
@@ -186,7 +187,7 @@ async function loadPreview() {
         SECRET iceberg_secret,
         ENDPOINT '${props.catalogUrl}'
       );
-      
+
       -- Query the table
       SELECT * FROM "${warehouseName.value}"."${props.namespaceId}"."${props.tableName}" LIMIT 1000;
     `;

--- a/src/components/WarehouseSqlQuery.vue
+++ b/src/components/WarehouseSqlQuery.vue
@@ -867,12 +867,14 @@ async function configureCatalogWithRetry(): Promise<boolean> {
     return false;
   }
 
+  const projectId = computed(() => visualStore.projectSelected['project-id']).value;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
       await icebergDB.configureCatalog({
         catalogName: props.warehouseName,
         restUri: props.catalogUrl,
         accessToken: accessToken,
+        projectId: projectId,
       });
       // Success!
       return true;

--- a/src/components/WarehouseSqlQuery.vue
+++ b/src/components/WarehouseSqlQuery.vue
@@ -431,7 +431,7 @@ const props = defineProps<{
 }>();
 
 const config = inject<any>('appConfig', { enabledAuthentication: false });
-const icebergDB = useIcebergDuckDB();
+const icebergDB = useIcebergDuckDB(config.baseUrlPrefix);
 const csvDownload = useCsvDownload();
 const visualStore = useVisualStore();
 const storageValidation = useStorageValidation(

--- a/src/composables/useDuckDB.ts
+++ b/src/composables/useDuckDB.ts
@@ -11,7 +11,7 @@ export interface QueryResult {
   rowCount: number;
 }
 
-export function useDuckDB() {
+export function useDuckDB(baseUrlPrefix: string) {
   const isInitialized: Ref<boolean> = ref(false);
   const isInitializing: Ref<boolean> = ref(false);
   const error: Ref<string | null> = ref(null);
@@ -25,12 +25,12 @@ export function useDuckDB() {
     error.value = null;
 
     try {
-      // Get the base URL for the current page including any base path (e.g., /ui/)
+      // Get the base URL for the current page including any base path (e.g., ${baseUrlPrefix}/ui/)
       const origin = window.location.origin;
       // Extract base path from pathname (e.g., /ui/ from /ui/warehouses/...)
       const pathname = window.location.pathname;
-      const basePath = pathname.split('/').slice(0, 2).join('/'); // Gets /ui or empty
-      const baseUrl = basePath ? `${origin}${basePath}` : origin;
+      const basePath = pathname.replace(baseUrlPrefix, '').split('/').slice(0, 2).join('/'); // Gets /ui or empty
+      const baseUrl = basePath ? `${origin}${baseUrlPrefix}${basePath}` : origin;
 
       // We'll use MVP bundle which is most compatible
       // and doesn't require exception handling support

--- a/src/composables/useIcebergDuckDB.ts
+++ b/src/composables/useIcebergDuckDB.ts
@@ -7,8 +7,8 @@ export interface IcebergCatalogConfig {
   accessToken: string;
 }
 
-export function useIcebergDuckDB() {
-  const duckDB = useDuckDB();
+export function useIcebergDuckDB(baseUrlPrefix: string) {
+  const duckDB = useDuckDB(baseUrlPrefix);
   const isLoadingTable = ref(false);
   const loadError = ref<string | null>(null);
   const catalogConfigured = ref(false);


### PR DESCRIPTION
## Summary

A couple of minor fixes related to the DuckDB query tab:

* Fixes failure to load DuckDB assets on a non-empty base path
* Fixes DuckDB attach statement for non-default project ids

### DuckDB assets

When the Lakekeeper UI sits on a non-empty base path, e.g. `/iceberg/ui`, it would fail to load the DuckDB WASM assets as the logic to strip the path components removed the `/iceberg` part:

<img width="1176" height="773" alt="image" src="https://github.com/user-attachments/assets/50dcd289-264b-46d3-a9ce-c503783f40ba" />

These changes pass the configured `baseUrlPrefix` through to `useDuckDB` function to allow it to find the assets.

## DuckDB attach for non-default project ids

In the case where a non-default project is used then the DuckDB attach statement requires the project id be prefixed to the catalog name.