### PR TITLE
fix:  add fuzzy search with scroll-to-node and active…

### DIFF
--- a/src/components/TablePreview.vue
+++ b/src/components/TablePreview.vue
@@ -131,14 +131,14 @@ const tableRows = computed(() => {
   });
 });
 
-// Check if preview is available - following same logic as WarehouseSqlQuery
+// Check if preview is available
 const isPreviewAvailable = computed(() => {
   // Wait for storage type to be loaded first
   if (!props.storageType) {
     return { available: false, reason: 'Loading warehouse information...' };
   }
 
-  // Use composable for storage validation (same as WarehouseSqlQuery)
+  // Use composable for storage validation
   if (!storageValidation.isOperationAvailable.value.available) {
     return {
       available: false,

--- a/src/components/WarehouseNavigationTree.vue
+++ b/src/components/WarehouseNavigationTree.vue
@@ -1,3 +1,4 @@
+<!-- @deprecated Use LoQENavigationTree instead. This component will be removed in a future release. -->
 <template>
   <v-sheet class="d-flex flex-column" height="100%" style="overflow: hidden">
     <v-sheet class="text-subtitle-2 py-2 px-3 flex-shrink-0" color="grey-lighten-4">

--- a/src/components/WarehouseSqlQuery.vue
+++ b/src/components/WarehouseSqlQuery.vue
@@ -1,3 +1,4 @@
+<!-- @deprecated Use LoQEExplorer instead. This component will be removed in a future release. -->
 <template>
   <v-container fluid class="pa-0">
     <div style="display: flex; height: calc(100vh - 200px); position: relative">

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,9 @@ import TableBranch from './components/TableBranch.vue';
 import TablePreview from './components/TablePreview.vue';
 import TableCreate from './components/TableCreate.vue';
 import TableRegister from './components/TableRegister.vue';
+/** @deprecated Use LoQEExplorer instead. Will be removed in a future release. */
 import WarehouseSqlQuery from './components/WarehouseSqlQuery.vue';
+/** @deprecated Use LoQENavigationTree instead. Will be removed in a future release. */
 import WarehouseNavigationTree from './components/WarehouseNavigationTree.vue';
 import WarehousesNavigationTree from './components/WarehousesNavigationTree.vue';
 import LoQEExplorer from './components/LoQEExplorer.vue';
@@ -272,7 +274,9 @@ const components = {
   TableCreate,
   TableRegister,
   TableBranch,
+  /** @deprecated Use LoQEExplorer instead. */
   WarehouseSqlQuery,
+  /** @deprecated Use LoQENavigationTree instead. */
   WarehouseNavigationTree,
   ViewHeader,
   ViewHistoryTab,

--- a/src/stores/visual.ts
+++ b/src/stores/visual.ts
@@ -40,6 +40,7 @@ export const useVisualStore = defineStore(
     const namespacePath = ref('');
     const savedSqlQuery = ref(''); // Store last SQL query (deprecated - use warehouseSqlData)
     const isNavigationCollapsed = ref(false); // Navigation tree collapsed state
+    const dismissSearchOnClick = ref(false); // LoQE tree: auto-dismiss search results on click
 
     // Requested tab for namespace detail page (set by navigation tree context menu)
     const requestedNamespaceTab = ref<string | null>(null);
@@ -267,6 +268,7 @@ export const useVisualStore = defineStore(
       savedSqlQuery,
       warehouseSqlData,
       isNavigationCollapsed,
+      dismissSearchOnClick,
       requestedNamespaceTab,
       warehouseTreeState,
       projectList,


### PR DESCRIPTION

- Add warehouse selector + search field using searchTabular API
- Show search results with match percentage chips and insert button
- Expand tree to result path and scroll into view via data-node-id attribute
- Highlight focused node with primary color (tree-item-active class)
- Add auto-close search results option (persisted in visual store)
- Deprecate WarehouseSqlQuery and WarehouseNavigationTree
- Remove stale WarehouseSqlQuery references in comments