### PR TITLE
fix: correct style.css exports path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
       "import": "./dist/console-components.es.js",
       "require": "./dist/console-components.umd.js"
     },
-    "./style.css": "./dist/style.css"
+    "./style.css": "./dist/console-components.css"
   },
   "files": [
     "dist"


### PR DESCRIPTION
The exports map pointed to `./dist/style.css` but Vite produces `./dist/console-components.css`. This caused build failures in consumer apps importing `@lakekeeper/console-components/style.css`.