### PR TITLE
fix(ui): adapt component heights for 14-inch MacBook screens

### DIFF
--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app-bar :elevation="2">
+  <v-app-bar :elevation="2" density="compact">
     <template #prepend>
       <v-app-bar-nav-icon :icon="navIcon" @click="navBar"></v-app-bar-nav-icon>
     </template>

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer app height="40">
+  <v-footer app height="32">
     <slot name="app-links"></slot>
     <div class="text-caption text-disabled" style="position: absolute; right: 16px">
       &copy; {{ new Date().getFullYear() }}

--- a/src/components/BreadcrumbsFromUrl.vue
+++ b/src/components/BreadcrumbsFromUrl.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-breadcrumbs :items="breadcrumbs">
+  <v-breadcrumbs :items="breadcrumbs" density="compact">
     <v-breadcrumbs-item />
     <template #divider>
       <v-icon icon="mdi-chevron-right"></v-icon>

--- a/src/components/HomeStatistics.vue
+++ b/src/components/HomeStatistics.vue
@@ -242,7 +242,7 @@ function drawChart() {
 
   const margin = { top: 12, right: 16, bottom: 36, left: 44 };
   const width = el.clientWidth - margin.left - margin.right;
-  const height = 180 - margin.top - margin.bottom;
+  const height = 140 - margin.top - margin.bottom;
 
   const data = chartData.value;
 
@@ -456,6 +456,6 @@ onMounted(() => {
 .chart-container {
   position: relative;
   width: 100%;
-  min-height: 180px;
+  min-height: 140px;
 }
 </style>

--- a/src/components/LoQEExplorer.vue
+++ b/src/components/LoQEExplorer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="pa-0">
+  <v-container fluid class="pa-0" style="height: 100%; overflow: hidden">
     <!-- ── Top Status Bar ────────────────────────────────────────── -->
     <v-toolbar density="compact" flat color="transparent" class="border-b">
       <v-toolbar-title class="text-subtitle-1 font-weight-bold">
@@ -81,7 +81,7 @@
     </v-toolbar>
 
     <!-- ── Main Layout ───────────────────────────────────────────── -->
-    <div style="display: flex; height: calc(100vh - 250px)">
+    <div style="display: flex; height: calc(100% - 48px)">
       <!-- Left Sidebar -->
       <v-expand-x-transition>
         <div

--- a/src/components/ProjectManager.vue
+++ b/src/components/ProjectManager.vue
@@ -35,7 +35,7 @@
           Statistics
         </v-tab>
       </v-tabs>
-      <v-tabs-window v-model="tab">
+      <v-tabs-window v-model="tab" style="max-height: calc(100vh - 140px); overflow-y: auto">
         <v-tabs-window-item value="overview" v-if="userStorage.isAuthenticated">
           <v-list lines="two" subheader>
             <v-list-subheader>Selected Project</v-list-subheader>
@@ -133,7 +133,7 @@
             :project-id="project['project-id']" />
         </v-tabs-window-item>
 
-        <v-tabs-window-item v-if="showStatisticsTab" value="statistics">
+        <v-tabs-window-item v-if="showStatisticsTab" value="statistics" style="height: 100%">
           <ProjectStatistics ref="projectStatisticsRef" />
         </v-tabs-window-item>
       </v-tabs-window>

--- a/src/components/ProjectManager.vue
+++ b/src/components/ProjectManager.vue
@@ -126,7 +126,10 @@
             :relation-type="permissionType" />
         </v-tabs-window-item>
 
-        <v-tabs-window-item v-if="showTasksTab && userStorage.isAuthenticated" value="tasks">
+        <v-tabs-window-item
+          v-if="showTasksTab && userStorage.isAuthenticated"
+          value="tasks"
+          style="height: 100%">
           <ProjectTaskManager
             v-if="project['project-id']"
             ref="projectTaskManagerRef"

--- a/src/components/ProjectStatistics.vue
+++ b/src/components/ProjectStatistics.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-card flat>
-    <v-card-text>
+  <v-card flat style="height: 100%; display: flex; flex-direction: column">
+    <v-card-text style="flex: 1; min-height: 0; overflow-y: auto">
       <!-- Controls row -->
       <div class="d-flex align-center ga-2 mb-2">
         <v-btn-toggle v-model="activeView" mandatory density="compact" variant="outlined">
@@ -143,7 +143,7 @@
       <div v-else-if="activeView === 'table'">
         <v-data-table-virtual
           fixed-header
-          height="60vh"
+          height="calc(100vh - 340px)"
           :headers="headersStatistics"
           hover
           :items="aggregatedRows"

--- a/src/components/ProjectTaskManager.vue
+++ b/src/components/ProjectTaskManager.vue
@@ -1,293 +1,289 @@
 <template>
   <v-card-text>
-    <v-row>
-      <v-col>
-        <v-toolbar color="transparent" density="compact" flat>
-          <v-toolbar-title>Project Task Management</v-toolbar-title>
-          <v-spacer></v-spacer>
-          <v-btn
-            color="secondary"
-            density="compact"
-            variant="outlined"
-            @click="openConfigDialog"
-            class="mr-2">
-            <v-icon start>mdi-cog</v-icon>
-            Task Log Config
-          </v-btn>
-          <v-btn
-            color="secondary"
-            density="compact"
-            variant="outlined"
-            @click="showFilters = !showFilters"
-            class="mr-2">
-            <v-icon start>mdi-filter-variant</v-icon>
-            Filters
-          </v-btn>
-          <v-btn color="primary" density="compact" variant="outlined" @click="refreshTasks">
-            <v-icon start>mdi-refresh</v-icon>
-            Refresh
-          </v-btn>
-        </v-toolbar>
+    <v-toolbar color="transparent" density="compact" flat>
+      <v-toolbar-title>Project Task Management</v-toolbar-title>
+      <v-spacer></v-spacer>
+      <v-btn
+        color="secondary"
+        density="compact"
+        variant="outlined"
+        @click="openConfigDialog"
+        class="mr-2">
+        <v-icon start>mdi-cog</v-icon>
+        Task Log Config
+      </v-btn>
+      <v-btn
+        color="secondary"
+        density="compact"
+        variant="outlined"
+        @click="showFilters = !showFilters"
+        class="mr-2">
+        <v-icon start>mdi-filter-variant</v-icon>
+        Filters
+      </v-btn>
+      <v-btn color="primary" density="compact" variant="outlined" @click="refreshTasks">
+        <v-icon start>mdi-refresh</v-icon>
+        Refresh
+      </v-btn>
+    </v-toolbar>
 
-        <!-- Filter Panel -->
-        <v-expand-transition>
-          <v-card v-show="showFilters" variant="outlined" class="mb-4">
-            <v-card-text>
-              <!-- Filter Groups -->
-              <v-row>
-                <v-col cols="12">
-                  <v-card variant="outlined" class="pa-3">
-                    <v-card-title class="text-subtitle-2 pb-2">General Filters</v-card-title>
-                    <v-row dense>
-                      <v-col cols="12" sm="4">
-                        <v-select
-                          v-model="filters.status"
-                          :items="statusOptions"
-                          label="Status"
-                          multiple
-                          chips
-                          clearable
-                          density="compact"
-                          hide-details>
-                          <template #chip="{ props, item }">
-                            <v-chip v-bind="props" :color="getStatusColor(item.value)" size="small">
-                              {{ item.title }}
-                            </v-chip>
-                          </template>
-                        </v-select>
-                      </v-col>
-                      <v-col cols="12" sm="4">
-                        <v-combobox
-                          v-model="filters.queueNames"
-                          :items="queueNameOptions"
-                          item-title="title"
-                          item-value="value"
-                          label="Task Types"
-                          multiple
-                          chips
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Select from common queues or enter custom names"></v-combobox>
-                      </v-col>
-                      <v-col cols="12" sm="4">
-                        <v-text-field
-                          v-model="filters.taskId"
-                          placeholder="01997633-d918-70f3-aec1-1889ae4bb232"
-                          label="Task ID"
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Filter by specific task ID"></v-text-field>
-                      </v-col>
-                    </v-row>
-                  </v-card>
-                </v-col>
-              </v-row>
+    <!-- Filter Panel -->
+    <v-expand-transition>
+      <v-card v-show="showFilters" variant="outlined" class="mb-4">
+        <v-card-text>
+          <!-- Filter Groups -->
+          <v-row>
+            <v-col cols="12">
+              <v-card variant="outlined" class="pa-3">
+                <v-card-title class="text-subtitle-2 pb-2">General Filters</v-card-title>
+                <v-row dense>
+                  <v-col cols="12" sm="4">
+                    <v-select
+                      v-model="filters.status"
+                      :items="statusOptions"
+                      label="Status"
+                      multiple
+                      chips
+                      clearable
+                      density="compact"
+                      hide-details>
+                      <template #chip="{ props, item }">
+                        <v-chip v-bind="props" :color="getStatusColor(item.value)" size="small">
+                          {{ item.title }}
+                        </v-chip>
+                      </template>
+                    </v-select>
+                  </v-col>
+                  <v-col cols="12" sm="4">
+                    <v-combobox
+                      v-model="filters.queueNames"
+                      :items="queueNameOptions"
+                      item-title="title"
+                      item-value="value"
+                      label="Task Types"
+                      multiple
+                      chips
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Select from common queues or enter custom names"></v-combobox>
+                  </v-col>
+                  <v-col cols="12" sm="4">
+                    <v-text-field
+                      v-model="filters.taskId"
+                      placeholder="01997633-d918-70f3-aec1-1889ae4bb232"
+                      label="Task ID"
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Filter by specific task ID"></v-text-field>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
 
-              <!-- Date Range Filters -->
-              <v-row>
-                <v-col cols="12" md="6">
-                  <v-card variant="outlined" class="pa-3">
-                    <v-card-title class="text-subtitle-2 pb-2">Created Date Range</v-card-title>
-                    <v-row dense>
-                      <v-col cols="12" sm="6">
-                        <v-text-field
-                          v-model="filters.createdAfter"
-                          label="After"
-                          type="datetime-local"
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Tasks created after this date"></v-text-field>
-                      </v-col>
-                      <v-col cols="12" sm="6">
-                        <v-text-field
-                          v-model="filters.createdBefore"
-                          label="Before"
-                          type="datetime-local"
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Tasks created before this date"></v-text-field>
-                      </v-col>
-                    </v-row>
-                  </v-card>
-                </v-col>
+          <!-- Date Range Filters -->
+          <v-row>
+            <v-col cols="12" md="6">
+              <v-card variant="outlined" class="pa-3">
+                <v-card-title class="text-subtitle-2 pb-2">Created Date Range</v-card-title>
+                <v-row dense>
+                  <v-col cols="12" sm="6">
+                    <v-text-field
+                      v-model="filters.createdAfter"
+                      label="After"
+                      type="datetime-local"
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Tasks created after this date"></v-text-field>
+                  </v-col>
+                  <v-col cols="12" sm="6">
+                    <v-text-field
+                      v-model="filters.createdBefore"
+                      label="Before"
+                      type="datetime-local"
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Tasks created before this date"></v-text-field>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
 
-                <v-col cols="12" md="6">
-                  <v-card variant="outlined" class="pa-3">
-                    <v-card-title class="text-subtitle-2 pb-2">Scheduled Date Range</v-card-title>
-                    <v-row dense>
-                      <v-col cols="12" sm="6">
-                        <v-text-field
-                          v-model="filters.scheduledAfter"
-                          label="After"
-                          type="datetime-local"
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Tasks scheduled after this date"></v-text-field>
-                      </v-col>
-                      <v-col cols="12" sm="6">
-                        <v-text-field
-                          v-model="filters.scheduledBefore"
-                          label="Before"
-                          type="datetime-local"
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Tasks scheduled before this date"></v-text-field>
-                      </v-col>
-                    </v-row>
-                  </v-card>
-                </v-col>
-              </v-row>
+            <v-col cols="12" md="6">
+              <v-card variant="outlined" class="pa-3">
+                <v-card-title class="text-subtitle-2 pb-2">Scheduled Date Range</v-card-title>
+                <v-row dense>
+                  <v-col cols="12" sm="6">
+                    <v-text-field
+                      v-model="filters.scheduledAfter"
+                      label="After"
+                      type="datetime-local"
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Tasks scheduled after this date"></v-text-field>
+                  </v-col>
+                  <v-col cols="12" sm="6">
+                    <v-text-field
+                      v-model="filters.scheduledBefore"
+                      label="Before"
+                      type="datetime-local"
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Tasks scheduled before this date"></v-text-field>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
 
-              <v-row>
-                <v-col cols="12" class="d-flex align-center">
-                  <v-btn
-                    color="primary"
-                    density="compact"
-                    @click="applyFilters"
-                    :loading="tasksLoading">
-                    Apply Filters
-                  </v-btn>
-                  <v-btn
-                    color="secondary"
-                    density="compact"
-                    variant="outlined"
-                    class="ml-2"
-                    @click="clearFilters">
-                    Clear All
-                  </v-btn>
-                  <v-spacer></v-spacer>
-                  <v-chip v-if="hasActiveFilters" color="info" size="small">
-                    {{ activeFilterCount }} filter(s) active
-                  </v-chip>
-                </v-col>
-              </v-row>
-            </v-card-text>
-          </v-card>
-        </v-expand-transition>
-
-        <v-data-table
-          v-if="!hasError"
-          :loading="tasksLoading"
-          :headers="taskHeaders"
-          :items="tasks"
-          :items-per-page="currentPaginationOptions.itemsPerPage"
-          :items-per-page-options="[
-            { title: '25 items', value: 25 },
-            { title: '50 items', value: 50 },
-            { title: '100 items', value: 100 },
-          ]"
-          hover
-          density="compact"
-          fixed-header
-          :height="showFilters ? '40vh' : '60vh'"
-          @update:options="handlePaginationUpdate">
-          <template #item.status="{ item }">
-            <v-chip :color="getStatusColor(item.status)" size="small" variant="flat">
-              {{ item.status }}
-            </v-chip>
-          </template>
-
-          <template #item.task-id="{ item }">
-            <span style="display: flex; align-items: center">
+          <v-row>
+            <v-col cols="12" class="d-flex align-center">
               <v-btn
-                icon="mdi-content-copy"
-                size="small"
-                variant="flat"
-                @click="functions.copyToClipboard(item['task-id'])"></v-btn>
-              {{ item['task-id'] }}
-            </span>
-          </template>
-
-          <template #item.queue-name="{ item }">
-            {{ formatQueueName(item['queue-name']) }}
-          </template>
-
-          <template #item.progress="{ item }">
-            <v-progress-linear
-              :model-value="item.progress * 100"
-              :color="getStatusColor(item.status)"
-              height="6"
-              rounded></v-progress-linear>
-            <span class="text-caption">{{ Math.round(item.progress * 100) }}%</span>
-          </template>
-
-          <template #item.created-at="{ item }">
-            {{ formatDateTime(item['created-at']) }}
-          </template>
-
-          <template #item.scheduled-for="{ item }">
-            {{ formatDateTime(item['scheduled-for']) }}
-          </template>
-
-          <template #item.actions="{ item }">
-            <v-btn
-              icon="mdi-information"
-              size="small"
-              variant="text"
-              @click="viewTaskDetails(item)"></v-btn>
-            <v-btn
-              v-if="item.status === 'RUNNING' && canControlTasks"
-              icon="mdi-stop"
-              size="small"
-              variant="text"
-              color="warning"
-              @click="stopTask(item)"></v-btn>
-            <v-btn
-              v-if="['SCHEDULED', 'RUNNING'].includes(item.status) && canControlTasks"
-              icon="mdi-cancel"
-              size="small"
-              variant="text"
-              color="error"
-              @click="cancelTask(item)"></v-btn>
-            <v-btn
-              v-if="item.status === 'SCHEDULED' && canControlTasks"
-              icon="mdi-play"
-              size="small"
-              variant="text"
-              color="success"
-              @click="runTaskNow(item)"></v-btn>
-          </template>
-
-          <template #no-data>
-            <div class="text-center pa-4" v-if="hasError">
-              <v-icon size="64" color="warning">mdi-alert-circle-outline</v-icon>
-              <div class="text-h6 mt-2">Unable to load tasks</div>
-              <div class="text-subtitle-1 text-grey">
-                {{ errorMessage }}
-              </div>
-              <v-btn class="mt-3" color="primary" variant="outlined" @click="refreshTasks">
-                Try Again
+                color="primary"
+                density="compact"
+                @click="applyFilters"
+                :loading="tasksLoading">
+                Apply Filters
               </v-btn>
-            </div>
-            <div class="text-center pa-4" v-else>
-              <v-icon size="64" color="grey-lighten-1">mdi-clipboard-list-outline</v-icon>
-              <div class="text-h6 mt-2">No tasks found</div>
-              <div class="text-subtitle-1 text-grey">
-                No tasks have been created for this project yet.
-              </div>
-            </div>
-          </template>
-        </v-data-table>
+              <v-btn
+                color="secondary"
+                density="compact"
+                variant="outlined"
+                class="ml-2"
+                @click="clearFilters">
+                Clear All
+              </v-btn>
+              <v-spacer></v-spacer>
+              <v-chip v-if="hasActiveFilters" color="info" size="small">
+                {{ activeFilterCount }} filter(s) active
+              </v-chip>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+    </v-expand-transition>
 
-        <!-- Error state display when data table is hidden -->
-        <div v-if="hasError" class="text-center pa-8">
+    <v-data-table
+      v-if="!hasError"
+      :loading="tasksLoading"
+      :headers="taskHeaders"
+      :items="tasks"
+      :items-per-page="currentPaginationOptions.itemsPerPage"
+      :items-per-page-options="[
+        { title: '25 items', value: 25 },
+        { title: '50 items', value: 50 },
+        { title: '100 items', value: 100 },
+      ]"
+      hover
+      density="compact"
+      fixed-header
+      :height="showFilters ? 'calc(100vh - 560px)' : 'calc(100vh - 280px)'"
+      @update:options="handlePaginationUpdate">
+      <template #item.status="{ item }">
+        <v-chip :color="getStatusColor(item.status)" size="small" variant="flat">
+          {{ item.status }}
+        </v-chip>
+      </template>
+
+      <template #item.task-id="{ item }">
+        <span style="display: flex; align-items: center">
+          <v-btn
+            icon="mdi-content-copy"
+            size="small"
+            variant="flat"
+            @click="functions.copyToClipboard(item['task-id'])"></v-btn>
+          {{ item['task-id'] }}
+        </span>
+      </template>
+
+      <template #item.queue-name="{ item }">
+        {{ formatQueueName(item['queue-name']) }}
+      </template>
+
+      <template #item.progress="{ item }">
+        <v-progress-linear
+          :model-value="item.progress * 100"
+          :color="getStatusColor(item.status)"
+          height="6"
+          rounded></v-progress-linear>
+        <span class="text-caption">{{ Math.round(item.progress * 100) }}%</span>
+      </template>
+
+      <template #item.created-at="{ item }">
+        {{ formatDateTime(item['created-at']) }}
+      </template>
+
+      <template #item.scheduled-for="{ item }">
+        {{ formatDateTime(item['scheduled-for']) }}
+      </template>
+
+      <template #item.actions="{ item }">
+        <v-btn
+          icon="mdi-information"
+          size="small"
+          variant="text"
+          @click="viewTaskDetails(item)"></v-btn>
+        <v-btn
+          v-if="item.status === 'RUNNING' && canControlTasks"
+          icon="mdi-stop"
+          size="small"
+          variant="text"
+          color="warning"
+          @click="stopTask(item)"></v-btn>
+        <v-btn
+          v-if="['SCHEDULED', 'RUNNING'].includes(item.status) && canControlTasks"
+          icon="mdi-cancel"
+          size="small"
+          variant="text"
+          color="error"
+          @click="cancelTask(item)"></v-btn>
+        <v-btn
+          v-if="item.status === 'SCHEDULED' && canControlTasks"
+          icon="mdi-play"
+          size="small"
+          variant="text"
+          color="success"
+          @click="runTaskNow(item)"></v-btn>
+      </template>
+
+      <template #no-data>
+        <div class="text-center pa-4" v-if="hasError">
           <v-icon size="64" color="warning">mdi-alert-circle-outline</v-icon>
           <div class="text-h6 mt-2">Unable to load tasks</div>
-          <div class="text-subtitle-1 text-grey mb-4">
+          <div class="text-subtitle-1 text-grey">
             {{ errorMessage }}
           </div>
-          <v-btn color="primary" variant="outlined" @click="refreshTasks" :loading="tasksLoading">
+          <v-btn class="mt-3" color="primary" variant="outlined" @click="refreshTasks">
             Try Again
           </v-btn>
         </div>
-      </v-col>
-    </v-row>
+        <div class="text-center pa-4" v-else>
+          <v-icon size="64" color="grey-lighten-1">mdi-clipboard-list-outline</v-icon>
+          <div class="text-h6 mt-2">No tasks found</div>
+          <div class="text-subtitle-1 text-grey">
+            No tasks have been created for this project yet.
+          </div>
+        </div>
+      </template>
+    </v-data-table>
+
+    <!-- Error state display when data table is hidden -->
+    <div v-if="hasError" class="text-center pa-8">
+      <v-icon size="64" color="warning">mdi-alert-circle-outline</v-icon>
+      <div class="text-h6 mt-2">Unable to load tasks</div>
+      <div class="text-subtitle-1 text-grey mb-4">
+        {{ errorMessage }}
+      </div>
+      <v-btn color="primary" variant="outlined" @click="refreshTasks" :loading="tasksLoading">
+        Try Again
+      </v-btn>
+    </div>
 
     <!-- Task Details Modal -->
     <v-dialog v-model="showTaskDetailsDialog" max-width="900px" scrollable>

--- a/src/components/RoleManager.vue
+++ b/src/components/RoleManager.vue
@@ -12,7 +12,7 @@
     </v-toolbar>
     <v-data-table
       v-if="canListRoles"
-      height="75vh"
+      height="calc(100vh - 340px)"
       items-per-page="50"
       fixed-header
       :headers="headers"

--- a/src/components/ServerOverview.vue
+++ b/src/components/ServerOverview.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="pa-4">
+  <v-container fluid class="pa-4" style="max-height: calc(100vh - 200px); overflow-y: auto">
     <!-- Server Information -->
     <v-card class="mb-4" elevation="1">
       <v-toolbar color="transparent" density="compact" flat>

--- a/src/components/StatisticsProject.vue
+++ b/src/components/StatisticsProject.vue
@@ -29,7 +29,7 @@
         <v-col>
           <v-data-table-virtual
             fixed-header
-            height="60vh"
+            height="calc(100vh - 340px)"
             :headers="headersStatistics"
             hover
             :items="tableStatisticsFormatted">

--- a/src/components/TableDetails.vue
+++ b/src/components/TableDetails.vue
@@ -20,7 +20,7 @@
             </v-chip>
           </v-toolbar>
           <v-divider></v-divider>
-          <v-table density="compact" fixed-header height="288px">
+          <v-table density="compact" fixed-header height="200px">
             <tbody>
               <tr>
                 <td class="font-weight-medium" style="width: 200px">Table UUID</td>
@@ -129,7 +129,7 @@
             :items="propertyItems"
             density="compact"
             fixed-header
-            height="288px"
+            height="200px"
             item-value="key"
             hide-default-footer
             :items-per-page="-1">

--- a/src/components/TableVersioningVisualization.vue
+++ b/src/components/TableVersioningVisualization.vue
@@ -1221,18 +1221,12 @@ const graphLinks = computed<GraphLink[]>(() => {
   // For main branch: draw links between consecutive snapshot-log entries
   // (skips snapshots that were merged in from other branches).
   if (mainBr && logIds.size > 0) {
-    const snapshotLog = (props.table.metadata as any)?.['snapshot-log'] as
-      | Array<{ 'snapshot-id': number }>
-      | undefined;
-    if (snapshotLog) {
-      const mainLogOrdered = snapshotLog
-        .map((entry) => entry['snapshot-id'])
-        .filter((id) => mainBr.ancestry.includes(id));
-      for (let i = 0; i < mainLogOrdered.length - 1; i++) {
-        const parentNode = nodeMap.get(mainLogOrdered[i]);
-        const childNode = nodeMap.get(mainLogOrdered[i + 1]);
-        if (parentNode && childNode) addLink(parentNode, childNode, mainBr.color, 0.8);
-      }
+    // Derive ordered list from ancestry (topological order) filtered to snapshot-log IDs
+    const mainLogOrdered = mainBr.ancestry.filter((id) => logIds.has(id));
+    for (let i = 0; i < mainLogOrdered.length - 1; i++) {
+      const parentNode = nodeMap.get(mainLogOrdered[i]);
+      const childNode = nodeMap.get(mainLogOrdered[i + 1]);
+      if (parentNode && childNode) addLink(parentNode, childNode, mainBr.color, 0.8);
     }
   }
 
@@ -1268,22 +1262,13 @@ const graphLinks = computed<GraphLink[]>(() => {
     }
 
     // Divergence from main: draw a colored link where the branch leaves main's owned set.
-    // Only draw if the child snapshot is NOT owned by main (i.e. an actual fork exists).
+    // Only draw if the fork edge wasn't already drawn in the ancestry loop above.
+    // The ancestry loop skips pairs where BOTH are mainOwned, but draws the fork edge
+    // (mainOwned parent -> non-mainOwned child), so we only need to draw here if the
+    // ancestry loop was skipped (i.e. branch === mainBr with snapshot-log).
     if (branch.type === 'branch' && branch.name !== 'main' && branch.name !== 'master') {
-      if (mainBr) {
-        for (let i = 0; i < branch.ancestry.length; i++) {
-          if (
-            mainOwnedIds.has(branch.ancestry[i]) &&
-            i > 0 &&
-            !mainOwnedIds.has(branch.ancestry[i - 1])
-          ) {
-            const from = nodeMap.get(branch.ancestry[i]);
-            const to = nodeMap.get(branch.ancestry[i - 1]);
-            if (from && to) addLink(from, to, branch.color, 0.8, 'diverge-');
-            break;
-          }
-        }
-      }
+      // Fork edge is already drawn by the ancestry loop (it only skips when BOTH are mainOwned).
+      // No additional diverge link needed.
     }
 
     // Dropped branch divergence

--- a/src/components/TaskManager.vue
+++ b/src/components/TaskManager.vue
@@ -1,302 +1,296 @@
 <template>
-  <v-card-text>
-    <v-row>
-      <v-col>
-        <v-toolbar color="transparent" density="compact" flat>
-          <v-toolbar-title>Task Management</v-toolbar-title>
-          <v-spacer></v-spacer>
-          <v-btn
-            color="secondary"
-            density="compact"
-            variant="outlined"
-            @click="showFilters = !showFilters"
-            class="mr-2">
-            <v-icon start>mdi-filter-variant</v-icon>
-            Filters
-          </v-btn>
-          <v-btn color="primary" density="compact" variant="outlined" @click="refreshTasks">
-            <v-icon start>mdi-refresh</v-icon>
-            Refresh
-          </v-btn>
-        </v-toolbar>
+  <v-container fluid class="pa-0">
+    <v-toolbar color="transparent" density="compact" flat>
+      <v-toolbar-title>Task Management</v-toolbar-title>
+      <v-spacer></v-spacer>
+      <v-btn
+        color="secondary"
+        density="compact"
+        variant="outlined"
+        @click="showFilters = !showFilters"
+        class="mr-2">
+        <v-icon start>mdi-filter-variant</v-icon>
+        Filters
+      </v-btn>
+      <v-btn color="primary" density="compact" variant="outlined" @click="refreshTasks">
+        <v-icon start>mdi-refresh</v-icon>
+        Refresh
+      </v-btn>
+    </v-toolbar>
 
-        <!-- Filter Panel -->
-        <v-expand-transition>
-          <v-card v-show="showFilters" variant="outlined" class="mb-4">
-            <v-card-text>
-              <!-- Filter Groups -->
-              <v-row>
-                <v-col cols="12">
-                  <v-card variant="outlined" class="pa-3">
-                    <v-card-title class="text-subtitle-2 pb-2">General Filters</v-card-title>
-                    <v-row dense>
-                      <v-col cols="12" sm="4">
-                        <v-select
-                          v-model="filters.status"
-                          :items="statusOptions"
-                          label="Status"
-                          multiple
-                          chips
-                          clearable
-                          density="compact"
-                          hide-details>
-                          <template #chip="{ props, item }">
-                            <v-chip v-bind="props" :color="getStatusColor(item.value)" size="small">
-                              {{ item.title }}
-                            </v-chip>
-                          </template>
-                        </v-select>
-                      </v-col>
-                      <v-col cols="12" sm="4">
-                        <v-combobox
-                          v-model="filters.queueNames"
-                          :items="queueNameOptions"
-                          item-title="title"
-                          item-value="value"
-                          label="Task Types"
-                          multiple
-                          chips
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Select from common queues or enter custom names"></v-combobox>
-                      </v-col>
-                      <v-col cols="12" sm="4">
-                        <v-text-field
-                          v-model="filters.taskId"
-                          placeholder="01997633-d918-70f3-aec1-1889ae4bb232"
-                          label="Task ID"
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Filter by specific task ID"></v-text-field>
-                      </v-col>
-                    </v-row>
-                  </v-card>
-                </v-col>
-              </v-row>
+    <!-- Filter Panel -->
+    <v-expand-transition>
+      <v-card v-show="showFilters" variant="outlined" class="mb-4">
+        <v-card-text>
+          <!-- Filter Groups -->
+          <v-row>
+            <v-col cols="12">
+              <v-card variant="outlined" class="pa-3">
+                <v-card-title class="text-subtitle-2 pb-2">General Filters</v-card-title>
+                <v-row dense>
+                  <v-col cols="12" sm="4">
+                    <v-select
+                      v-model="filters.status"
+                      :items="statusOptions"
+                      label="Status"
+                      multiple
+                      chips
+                      clearable
+                      density="compact"
+                      hide-details>
+                      <template #chip="{ props, item }">
+                        <v-chip v-bind="props" :color="getStatusColor(item.value)" size="small">
+                          {{ item.title }}
+                        </v-chip>
+                      </template>
+                    </v-select>
+                  </v-col>
+                  <v-col cols="12" sm="4">
+                    <v-combobox
+                      v-model="filters.queueNames"
+                      :items="queueNameOptions"
+                      item-title="title"
+                      item-value="value"
+                      label="Task Types"
+                      multiple
+                      chips
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Select from common queues or enter custom names"></v-combobox>
+                  </v-col>
+                  <v-col cols="12" sm="4">
+                    <v-text-field
+                      v-model="filters.taskId"
+                      placeholder="01997633-d918-70f3-aec1-1889ae4bb232"
+                      label="Task ID"
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Filter by specific task ID"></v-text-field>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
 
-              <!-- Date Range Filters -->
-              <v-row>
-                <v-col cols="12" md="6">
-                  <v-card variant="outlined" class="pa-3">
-                    <v-card-title class="text-subtitle-2 pb-2">Created Date Range</v-card-title>
-                    <v-row dense>
-                      <v-col cols="12" sm="6">
-                        <v-text-field
-                          v-model="filters.createdAfter"
-                          label="After"
-                          type="datetime-local"
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Tasks created after this date"></v-text-field>
-                      </v-col>
-                      <v-col cols="12" sm="6">
-                        <v-text-field
-                          v-model="filters.createdBefore"
-                          label="Before"
-                          type="datetime-local"
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Tasks created before this date"></v-text-field>
-                      </v-col>
-                    </v-row>
-                  </v-card>
-                </v-col>
+          <!-- Date Range Filters -->
+          <v-row>
+            <v-col cols="12" md="6">
+              <v-card variant="outlined" class="pa-3">
+                <v-card-title class="text-subtitle-2 pb-2">Created Date Range</v-card-title>
+                <v-row dense>
+                  <v-col cols="12" sm="6">
+                    <v-text-field
+                      v-model="filters.createdAfter"
+                      label="After"
+                      type="datetime-local"
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Tasks created after this date"></v-text-field>
+                  </v-col>
+                  <v-col cols="12" sm="6">
+                    <v-text-field
+                      v-model="filters.createdBefore"
+                      label="Before"
+                      type="datetime-local"
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Tasks created before this date"></v-text-field>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
 
-                <v-col cols="12" md="6">
-                  <v-card variant="outlined" class="pa-3">
-                    <v-card-title class="text-subtitle-2 pb-2">Scheduled Date Range</v-card-title>
-                    <v-row dense>
-                      <v-col cols="12" sm="6">
-                        <v-text-field
-                          v-model="filters.scheduledAfter"
-                          label="After"
-                          type="datetime-local"
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Tasks scheduled after this date"></v-text-field>
-                      </v-col>
-                      <v-col cols="12" sm="6">
-                        <v-text-field
-                          v-model="filters.scheduledBefore"
-                          label="Before"
-                          type="datetime-local"
-                          clearable
-                          density="compact"
-                          hide-details
-                          hint="Tasks scheduled before this date"></v-text-field>
-                      </v-col>
-                    </v-row>
-                  </v-card>
-                </v-col>
-              </v-row>
+            <v-col cols="12" md="6">
+              <v-card variant="outlined" class="pa-3">
+                <v-card-title class="text-subtitle-2 pb-2">Scheduled Date Range</v-card-title>
+                <v-row dense>
+                  <v-col cols="12" sm="6">
+                    <v-text-field
+                      v-model="filters.scheduledAfter"
+                      label="After"
+                      type="datetime-local"
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Tasks scheduled after this date"></v-text-field>
+                  </v-col>
+                  <v-col cols="12" sm="6">
+                    <v-text-field
+                      v-model="filters.scheduledBefore"
+                      label="Before"
+                      type="datetime-local"
+                      clearable
+                      density="compact"
+                      hide-details
+                      hint="Tasks scheduled before this date"></v-text-field>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-col>
+          </v-row>
 
-              <v-row>
-                <v-col cols="12" class="d-flex align-center">
-                  <v-btn
-                    color="primary"
-                    density="compact"
-                    @click="applyFilters"
-                    :loading="tasksLoading">
-                    Apply Filters
-                  </v-btn>
-                  <v-btn
-                    color="secondary"
-                    density="compact"
-                    variant="outlined"
-                    class="ml-2"
-                    @click="clearFilters">
-                    Clear All
-                  </v-btn>
-                  <v-spacer></v-spacer>
-                  <v-chip v-if="hasActiveFilters" color="info" size="small">
-                    {{ activeFilterCount }} filter(s) active
-                  </v-chip>
-                </v-col>
-              </v-row>
-            </v-card-text>
-          </v-card>
-        </v-expand-transition>
-
-        <v-data-table
-          v-if="!hasError"
-          :loading="tasksLoading"
-          :headers="taskHeaders"
-          :items="tasks"
-          :items-per-page="currentPaginationOptions.itemsPerPage"
-          :items-per-page-options="[
-            { title: '25 items', value: 25 },
-            { title: '50 items', value: 50 },
-            { title: '100 items', value: 100 },
-          ]"
-          hover
-          density="compact"
-          fixed-header
-          :height="showFilters ? '40vh' : '60vh'"
-          @update:options="handlePaginationUpdate">
-          <template #item.entity-name="{ item }">
-            <span
-              class="text-wrap"
-              style="
-                word-break: break-all;
-                white-space: normal;
-                line-height: 1.2;
-                max-width: 120px;
-                display: inline-block;
-                overflow-wrap: anywhere;
-              ">
-              {{
-                Array.isArray(item['entity-name'])
-                  ? item['entity-name'].join('.')
-                  : item['entity-name']
-              }}
-            </span>
-          </template>
-          <template #item.status="{ item }">
-            <v-chip :color="getStatusColor(item.status)" size="small" variant="flat">
-              {{ item.status }}
-            </v-chip>
-          </template>
-
-          <template #item.task-id="{ item }">
-            <span style="display: flex; align-items: center">
+          <v-row>
+            <v-col cols="12" class="d-flex align-center">
               <v-btn
-                icon="mdi-content-copy"
-                size="small"
-                variant="flat"
-                @click="functions.copyToClipboard(item['task-id'])"></v-btn>
-              {{ item['task-id'] }}
-            </span>
-          </template>
-
-          <template #item.queue-name="{ item }">
-            {{ formatQueueName(item['queue-name']) }}
-          </template>
-
-          <template #item.progress="{ item }">
-            <v-progress-linear
-              :model-value="item.progress * 100"
-              :color="getStatusColor(item.status)"
-              height="6"
-              rounded></v-progress-linear>
-            <span class="text-caption">{{ Math.round(item.progress * 100) }}%</span>
-          </template>
-
-          <template #item.created-at="{ item }">
-            {{ formatDateTime(item['created-at']) }}
-          </template>
-
-          <template #item.scheduled-for="{ item }">
-            {{ formatDateTime(item['scheduled-for']) }}
-          </template>
-
-          <template #item.actions="{ item }">
-            <v-btn
-              icon="mdi-information"
-              size="small"
-              variant="text"
-              @click="viewTaskDetails(item)"></v-btn>
-            <v-btn
-              v-if="item.status === 'RUNNING' && canControlTasks"
-              icon="mdi-stop"
-              size="small"
-              variant="text"
-              color="warning"
-              @click="stopTask(item)"></v-btn>
-            <v-btn
-              v-if="['SCHEDULED', 'RUNNING'].includes(item.status) && canControlTasks"
-              icon="mdi-cancel"
-              size="small"
-              variant="text"
-              color="error"
-              @click="cancelTask(item)"></v-btn>
-            <v-btn
-              v-if="item.status === 'SCHEDULED' && canControlTasks"
-              icon="mdi-play"
-              size="small"
-              variant="text"
-              color="success"
-              @click="runTaskNow(item)"></v-btn>
-          </template>
-
-          <template #no-data>
-            <div class="text-center pa-4" v-if="hasError">
-              <v-icon size="64" color="warning">mdi-alert-circle-outline</v-icon>
-              <div class="text-h6 mt-2">Unable to load tasks</div>
-              <div class="text-subtitle-1 text-grey">
-                {{ errorMessage }}
-              </div>
-              <v-btn class="mt-3" color="primary" variant="outlined" @click="refreshTasks">
-                Try Again
+                color="primary"
+                density="compact"
+                @click="applyFilters"
+                :loading="tasksLoading">
+                Apply Filters
               </v-btn>
-            </div>
-            <div class="text-center pa-4" v-else>
-              <v-icon size="64" color="grey-lighten-1">mdi-clipboard-list-outline</v-icon>
-              <div class="text-h6 mt-2">No tasks found</div>
-              <div class="text-subtitle-1 text-grey">
-                No tasks have been created for this {{ props.entityType || 'warehouse' }} yet.
-              </div>
-            </div>
-          </template>
-        </v-data-table>
+              <v-btn
+                color="secondary"
+                density="compact"
+                variant="outlined"
+                class="ml-2"
+                @click="clearFilters">
+                Clear All
+              </v-btn>
+              <v-spacer></v-spacer>
+              <v-chip v-if="hasActiveFilters" color="info" size="small">
+                {{ activeFilterCount }} filter(s) active
+              </v-chip>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+    </v-expand-transition>
 
-        <!-- Error state display when data table is hidden -->
-        <div v-if="hasError" class="text-center pa-8">
+    <v-data-table
+      v-if="!hasError"
+      :loading="tasksLoading"
+      :headers="taskHeaders"
+      :items="tasks"
+      :items-per-page="currentPaginationOptions.itemsPerPage"
+      :items-per-page-options="[
+        { title: '25 items', value: 25 },
+        { title: '50 items', value: 50 },
+        { title: '100 items', value: 100 },
+      ]"
+      hover
+      density="compact"
+      fixed-header
+      :height="showFilters ? 'calc(100vh - 610px)' : 'calc(100vh - 380px)'"
+      @update:options="handlePaginationUpdate">
+      <template #item.entity-name="{ item }">
+        <span
+          class="text-wrap"
+          style="
+            word-break: break-all;
+            white-space: normal;
+            line-height: 1.2;
+            max-width: 120px;
+            display: inline-block;
+            overflow-wrap: anywhere;
+          ">
+          {{
+            Array.isArray(item['entity-name']) ? item['entity-name'].join('.') : item['entity-name']
+          }}
+        </span>
+      </template>
+      <template #item.status="{ item }">
+        <v-chip :color="getStatusColor(item.status)" size="small" variant="flat">
+          {{ item.status }}
+        </v-chip>
+      </template>
+
+      <template #item.task-id="{ item }">
+        <span style="display: flex; align-items: center">
+          <v-btn
+            icon="mdi-content-copy"
+            size="small"
+            variant="flat"
+            @click="functions.copyToClipboard(item['task-id'])"></v-btn>
+          {{ item['task-id'] }}
+        </span>
+      </template>
+
+      <template #item.queue-name="{ item }">
+        {{ formatQueueName(item['queue-name']) }}
+      </template>
+
+      <template #item.progress="{ item }">
+        <v-progress-linear
+          :model-value="item.progress * 100"
+          :color="getStatusColor(item.status)"
+          height="6"
+          rounded></v-progress-linear>
+        <span class="text-caption">{{ Math.round(item.progress * 100) }}%</span>
+      </template>
+
+      <template #item.created-at="{ item }">
+        {{ formatDateTime(item['created-at']) }}
+      </template>
+
+      <template #item.scheduled-for="{ item }">
+        {{ formatDateTime(item['scheduled-for']) }}
+      </template>
+
+      <template #item.actions="{ item }">
+        <v-btn
+          icon="mdi-information"
+          size="small"
+          variant="text"
+          @click="viewTaskDetails(item)"></v-btn>
+        <v-btn
+          v-if="item.status === 'RUNNING' && canControlTasks"
+          icon="mdi-stop"
+          size="small"
+          variant="text"
+          color="warning"
+          @click="stopTask(item)"></v-btn>
+        <v-btn
+          v-if="['SCHEDULED', 'RUNNING'].includes(item.status) && canControlTasks"
+          icon="mdi-cancel"
+          size="small"
+          variant="text"
+          color="error"
+          @click="cancelTask(item)"></v-btn>
+        <v-btn
+          v-if="item.status === 'SCHEDULED' && canControlTasks"
+          icon="mdi-play"
+          size="small"
+          variant="text"
+          color="success"
+          @click="runTaskNow(item)"></v-btn>
+      </template>
+
+      <template #no-data>
+        <div class="text-center pa-4" v-if="hasError">
           <v-icon size="64" color="warning">mdi-alert-circle-outline</v-icon>
           <div class="text-h6 mt-2">Unable to load tasks</div>
-          <div class="text-subtitle-1 text-grey mb-4">
+          <div class="text-subtitle-1 text-grey">
             {{ errorMessage }}
           </div>
-          <v-btn color="primary" variant="outlined" @click="refreshTasks" :loading="tasksLoading">
+          <v-btn class="mt-3" color="primary" variant="outlined" @click="refreshTasks">
             Try Again
           </v-btn>
         </div>
-      </v-col>
-    </v-row>
+        <div class="text-center pa-4" v-else>
+          <v-icon size="64" color="grey-lighten-1">mdi-clipboard-list-outline</v-icon>
+          <div class="text-h6 mt-2">No tasks found</div>
+          <div class="text-subtitle-1 text-grey">
+            No tasks have been created for this {{ props.entityType || 'warehouse' }} yet.
+          </div>
+        </div>
+      </template>
+    </v-data-table>
+
+    <!-- Error state display when data table is hidden -->
+    <div v-if="hasError" class="text-center pa-8">
+      <v-icon size="64" color="warning">mdi-alert-circle-outline</v-icon>
+      <div class="text-h6 mt-2">Unable to load tasks</div>
+      <div class="text-subtitle-1 text-grey mb-4">
+        {{ errorMessage }}
+      </div>
+      <v-btn color="primary" variant="outlined" @click="refreshTasks" :loading="tasksLoading">
+        Try Again
+      </v-btn>
+    </div>
 
     <!-- Task Details Modal -->
     <v-dialog v-model="showTaskDetailsDialog" max-width="900px" scrollable>
@@ -430,7 +424,7 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
-  </v-card-text>
+  </v-container>
 </template>
 
 <script setup lang="ts">

--- a/src/components/UserManager.vue
+++ b/src/components/UserManager.vue
@@ -1,6 +1,6 @@
 <template>
   <v-data-table
-    height="75vh"
+    height="calc(100vh - 340px)"
     items-per-page="50"
     fixed-header
     :headers="headers"

--- a/src/components/ViewDetails.vue
+++ b/src/components/ViewDetails.vue
@@ -20,7 +20,7 @@
             </v-chip>
           </v-toolbar>
           <v-divider></v-divider>
-          <v-table density="compact" fixed-header height="288px">
+          <v-table density="compact" fixed-header height="200px">
             <tbody>
               <tr>
                 <td class="font-weight-medium" style="width: 200px">View UUID</td>
@@ -109,7 +109,7 @@
             :items="propertyItems"
             density="compact"
             fixed-header
-            height="288px"
+            height="200px"
             item-value="key"
             hide-default-footer
             :items-per-page="-1">

--- a/src/components/ViewOverview.vue
+++ b/src/components/ViewOverview.vue
@@ -14,13 +14,13 @@
         @click.prevent="showConfirmDialog"></v-switch>
     </v-toolbar>
     <ViewDetails
-        v-if="loaded"
-        :view="view"
-        :warehouse-id="props.warehouseId"
-        :namespace-path="props.namespaceId"
-        :view-name="props.viewName"
-        :can-edit="canCommit"
-        @updated="loadViewData" />
+      v-if="loaded"
+      :view="view"
+      :warehouse-id="props.warehouseId"
+      :namespace-path="props.namespaceId"
+      :view-name="props.viewName"
+      :can-edit="canCommit"
+      @updated="loadViewData" />
 
     <ProtectionConfirmDialog
       v-model="confirmDialog"

--- a/src/components/ViewOverview.vue
+++ b/src/components/ViewOverview.vue
@@ -13,8 +13,7 @@
         "
         @click.prevent="showConfirmDialog"></v-switch>
     </v-toolbar>
-    <v-card-text>
-      <ViewDetails
+    <ViewDetails
         v-if="loaded"
         :view="view"
         :warehouse-id="props.warehouseId"
@@ -22,7 +21,6 @@
         :view-name="props.viewName"
         :can-edit="canCommit"
         @updated="loadViewData" />
-    </v-card-text>
 
     <ProtectionConfirmDialog
       v-model="confirmDialog"

--- a/src/components/WarehouseDetails.vue
+++ b/src/components/WarehouseDetails.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid class="pa-0">
-    <div style="display: flex; height: calc(100vh - 200px); position: relative">
+    <div style="display: flex; height: calc(100vh - 160px); position: relative">
       <!-- Right: Warehouse Details Content -->
       <div style="flex: 1; height: 100%; overflow-y: auto; min-width: 0">
         <v-container fluid class="pa-6">

--- a/src/components/WarehouseManager.vue
+++ b/src/components/WarehouseManager.vue
@@ -40,7 +40,7 @@
 
     <v-data-table
       v-if="canListWarehouses"
-      height="60vh"
+      height="calc(100vh - 340px)"
       fixed-header
       :headers="headers"
       hover

--- a/src/components/WarehouseNamespaces.vue
+++ b/src/components/WarehouseNamespaces.vue
@@ -1,6 +1,6 @@
 <template>
   <v-data-table
-    height="60vh"
+    height="calc(100vh - 340px)"
     :search="searchNamespace"
     fixed-header
     :headers="headers"

--- a/src/components/WarehouseStatistics.vue
+++ b/src/components/WarehouseStatistics.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-card flat>
-    <v-card-text class="pa-0">
-      <div class="d-flex" style="min-height: 500px">
+  <v-card flat style="height: 100%">
+    <v-card-text class="pa-0" style="height: 100%">
+      <div class="d-flex" style="height: 100%; overflow: hidden">
         <!-- Vertical Tabs -->
         <v-tabs
           v-model="section"
@@ -15,7 +15,7 @@
         </v-tabs>
 
         <!-- Tab content -->
-        <div class="flex-grow-1 pa-4" style="min-width: 0; overflow: auto">
+        <div class="flex-grow-1 pa-4" style="min-width: 0; min-height: 0; height: 100%; overflow-y: auto">
           <v-tabs-window v-model="section">
             <!-- ════════════════════════════════════════════════════════════════
                  TAB 1 — Endpoint Statistics
@@ -148,7 +148,7 @@
               <div v-else-if="activeView === 'table'">
                 <v-data-table-virtual
                   fixed-header
-                  height="60vh"
+                  height="calc(100vh - 340px)"
                   :headers="endpointHeaders"
                   hover
                   :items="aggregatedRows"
@@ -233,7 +233,7 @@
               <div v-else-if="objectsView === 'table'">
                 <v-data-table-virtual
                   fixed-header
-                  height="60vh"
+                  height="calc(100vh - 340px)"
                   :headers="objectsHeaders"
                   hover
                   :items="aggregatedObjectsData"

--- a/src/components/WarehouseStatistics.vue
+++ b/src/components/WarehouseStatistics.vue
@@ -15,7 +15,9 @@
         </v-tabs>
 
         <!-- Tab content -->
-        <div class="flex-grow-1 pa-4" style="min-width: 0; min-height: 0; height: 100%; overflow-y: auto">
+        <div
+          class="flex-grow-1 pa-4"
+          style="min-width: 0; min-height: 0; height: 100%; overflow-y: auto">
           <v-tabs-window v-model="section">
             <!-- ════════════════════════════════════════════════════════════════
                  TAB 1 — Endpoint Statistics


### PR DESCRIPTION
Adapts all shared component heights and layouts to prevent page-level scrolling on 14-inch MacBook screens while maintaining proper behavior on larger displays.

fix(ui): AppBar and BreadcrumbsFromUrl add density=compact to reduce vertical space
fix(ui): AppFooter reduce height from 40px to 32px
fix(ui): replace fixed data table heights (60vh, 75vh, 288px) with calc-based responsive heights
fix(ui): WarehouseStatistics and ProjectStatistics use container-relative height with flex layout
fix(ui): LoQEExplorer fix height and overflow for proper container sizing
fix(ui): HomeStatistics reduce chart height from 180px to 140px
fix(ui): ServerOverview add max-height with overflow-y auto
fix(ui): ViewOverview remove double v-card-text wrapping
fix(ui): ProjectManager add overflow-y auto to tabs window and height propagation for statistics tab
fix(ui): TableVersioningVisualization fix snapshot-log ordering and remove diverge-pass double-draw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined UI spacing, compacted app bar and breadcrumbs, reduced footer height.
  * Tables and charts now use responsive height calculations (viewport- and container-aware) instead of fixed values.
  * Improved scrolling and content containment for cards, tabs, and detail views.

* **Refactor**
  * Reorganized task management interfaces and filter panel layout for clearer workflow.
  * Simplified version/branch rendering by relying on ancestry ordering for edge handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->