### PR TITLE
Fix: ui components

### DIFF
--- a/src/components/HomeStatistics.vue
+++ b/src/components/HomeStatistics.vue
@@ -50,7 +50,7 @@
     </v-row>
 
     <!-- API Calls Chart -->
-    <v-card variant="outlined" class="chart-card">
+    <v-card v-if="!chartForbidden" variant="outlined" class="chart-card">
       <v-card-text class="pa-3">
         <div class="d-flex align-center mb-2">
           <v-icon size="18" class="mr-2" color="primary">mdi-chart-line</v-icon>
@@ -83,6 +83,7 @@ const visual = useVisualStore();
 const loading = ref(true);
 const chartLoading = ref(true);
 const noChartData = ref(false);
+const chartForbidden = ref(false);
 const projects = ref(0);
 const warehouses = ref(0);
 const tables = ref(0);
@@ -139,8 +140,8 @@ async function loadCounts() {
 
     tables.value = totalTables;
     views.value = totalViews;
-  } catch (error) {
-    functions.handleError(error, 'HomeStatistics:loadCounts');
+  } catch {
+    // Silently ignore – counts are best-effort
   } finally {
     loading.value = false;
   }
@@ -222,8 +223,13 @@ async function loadChart() {
 
     await nextTick();
     drawChart();
-  } catch (error) {
-    functions.handleError(error, 'HomeStatistics:loadChart');
+  } catch (error: any) {
+    const status = error?.error?.code || error?.status || error?.response?.status || 0;
+    if (status === 403) {
+      chartForbidden.value = true;
+    } else {
+      functions.handleError(error, 'HomeStatistics:loadChart');
+    }
     noChartData.value = true;
   } finally {
     chartLoading.value = false;

--- a/src/components/NamespaceNamespaces.vue
+++ b/src/components/NamespaceNamespaces.vue
@@ -188,6 +188,9 @@ async function addNamespace(namespaceIdent: string[], properties: Record<string,
 
     addNamespaceStatus.value = StatusIntent.SUCCESS;
     await loadNamespaces();
+    // Signal nav tree to refresh this namespace's children
+    const parentNs = props.namespacePath.replace(/\x1F/g, '.');
+    visual.refreshNavTree(props.warehouseId, parentNs);
   } catch (error) {
     addNamespaceStatus.value = StatusIntent.FAILURE;
     console.error('Failed to create namespace:', error);
@@ -204,6 +207,9 @@ async function deleteNamespaceWithOptions(e: any, item: Item) {
     );
 
     await loadNamespaces();
+    // Signal nav tree to refresh this namespace's children
+    const parentNs = props.namespacePath.replace(/\x1F/g, '.');
+    visual.refreshNavTree(props.warehouseId, parentNs);
   } catch (error) {
     console.error(`Failed to drop namespace-${item.name}`, error);
   }

--- a/src/components/NamespaceNamespaces.vue
+++ b/src/components/NamespaceNamespaces.vue
@@ -189,7 +189,7 @@ async function addNamespace(namespaceIdent: string[], properties: Record<string,
     addNamespaceStatus.value = StatusIntent.SUCCESS;
     await loadNamespaces();
     // Signal nav tree to refresh this namespace's children
-    const parentNs = props.namespacePath.replace(/\x1F/g, '.');
+    const parentNs = props.namespacePath.split('\x1F').join('.');
     visual.refreshNavTree(props.warehouseId, parentNs);
   } catch (error) {
     addNamespaceStatus.value = StatusIntent.FAILURE;
@@ -208,7 +208,7 @@ async function deleteNamespaceWithOptions(e: any, item: Item) {
 
     await loadNamespaces();
     // Signal nav tree to refresh this namespace's children
-    const parentNs = props.namespacePath.replace(/\x1F/g, '.');
+    const parentNs = props.namespacePath.split('\x1F').join('.');
     visual.refreshNavTree(props.warehouseId, parentNs);
   } catch (error) {
     console.error(`Failed to drop namespace-${item.name}`, error);

--- a/src/components/WarehouseNamespaces.vue
+++ b/src/components/WarehouseNamespaces.vue
@@ -136,6 +136,7 @@ async function addNamespace(namespace: string[], properties: Record<string, stri
     createNamespaceStatus.value = StatusIntent.SUCCESS;
     await loadNamespaces();
     emit('namespace-updated');
+    visual.refreshNavTree(props.warehouseId);
   } catch (error) {
     createNamespaceStatus.value = StatusIntent.FAILURE;
     console.error('Failed to create namespace:', error);
@@ -246,6 +247,7 @@ async function deleteNamespaceWithOptions(e: any, item: Item) {
 
     await loadNamespaces();
     emit('namespace-updated');
+    visual.refreshNavTree(props.warehouseId);
   } catch (error: any) {
     console.error(`Failed to drop namespace-${item.name}  - `, error);
   }

--- a/src/components/WarehousesNavigationTree.vue
+++ b/src/components/WarehousesNavigationTree.vue
@@ -249,6 +249,7 @@ import cfIcon from '@/assets/cf.svg';
 const props = defineProps<{
   warehouseId?: string; // Optional: filter to show only this warehouse
   warehouseName?: string; // Optional: warehouse name for header
+  activeNamespacePath?: string; // Dot-separated namespace path to auto-expand to
 }>();
 
 const functions = useFunctions();
@@ -868,6 +869,10 @@ onMounted(async () => {
           openedItems.value = (savedState.openedItems || []).filter((id: string) =>
             validTreeItems.some((wh: TreeItem) => id === wh.id || id.includes(wh.warehouseId)),
           );
+          // Expand to active namespace path if provided
+          if (props.warehouseId && props.activeNamespacePath) {
+            await expandTreeToPath(props.warehouseId, props.activeNamespacePath);
+          }
           return;
         }
       }
@@ -878,6 +883,11 @@ onMounted(async () => {
 
   // No valid cache — load fresh
   await loadWarehouses();
+
+  // Expand to active namespace path if provided
+  if (props.warehouseId && props.activeNamespacePath) {
+    await expandTreeToPath(props.warehouseId, props.activeNamespacePath);
+  }
 });
 
 // Save tree state when it changes
@@ -911,6 +921,52 @@ watch(
     // Always reload fresh data when warehouse filter changes
     loadWarehouses();
   },
+);
+
+// Watch for activeNamespacePath changes and auto-expand tree to match current route
+watch(
+  () => props.activeNamespacePath,
+  async (newPath) => {
+    if (newPath && props.warehouseId) {
+      await expandTreeToPath(props.warehouseId, newPath);
+    }
+  },
+);
+
+// Watch for navTreeRefreshSignal to reload specific nodes when objects are created/deleted
+watch(
+  () => visualStore.navTreeRefreshSignal,
+  async (signal) => {
+    if (!signal.warehouseId) return;
+    // Only react if this tree instance shows the affected warehouse
+    if (props.warehouseId && props.warehouseId !== signal.warehouseId) return;
+
+    if (signal.namespaceId) {
+      // A namespace's children changed (table/view/sub-namespace created or deleted)
+      const nodeId = `namespace-${signal.warehouseId}-${signal.namespaceId}`;
+      const node = findItemById(treeItems.value, nodeId);
+      if (node) {
+        node.loaded = false;
+        await loadChildrenForNamespace(node);
+        // Ensure the node is expanded so the new child is visible
+        if (!openedItems.value.includes(nodeId)) {
+          openedItems.value = [...openedItems.value, nodeId];
+        }
+      }
+    } else {
+      // Warehouse-level change (namespace created/deleted at root)
+      const nodeId = `warehouse-${signal.warehouseId}`;
+      const node = findItemById(treeItems.value, nodeId);
+      if (node) {
+        node.loaded = false;
+        await loadNamespacesForWarehouse(node);
+        if (!openedItems.value.includes(nodeId)) {
+          openedItems.value = [...openedItems.value, nodeId];
+        }
+      }
+    }
+  },
+  { deep: true },
 );
 
 // Clean up on unmount

--- a/src/components/WarehousesNavigationTree.vue
+++ b/src/components/WarehousesNavigationTree.vue
@@ -550,15 +550,32 @@ async function loadWarehouses() {
   }
 }
 
-// Refresh warehouses and reset tree state
+// Refresh warehouses while preserving expanded state
 async function refreshWarehouses() {
-  openedItems.value = [];
+  const previouslyOpened = [...openedItems.value];
+
+  // Reload warehouse list from server
   await loadWarehouses();
 
-  // Clear saved state on refresh
-  if (storageKey.value) {
-    delete visualStore.warehouseTreeState[storageKey.value];
+  // Sort opened nodes by depth (parents first) so children are reachable after parent loads
+  const sorted = previouslyOpened.sort(
+    (a, b) => (a.match(/::/g) || []).length - (b.match(/::/g) || []).length,
+  );
+
+  // Re-expand previously opened nodes by reloading their children
+  for (const nodeId of sorted) {
+    const item = findItemById(treeItems.value, nodeId);
+    if (item) {
+      if (item.type === 'warehouse') {
+        await loadNamespacesForWarehouse(item);
+      } else if (item.type === 'namespace') {
+        await loadChildrenForNamespace(item);
+      }
+    }
   }
+
+  // Restore opened state, filtering out any nodes that no longer exist
+  openedItems.value = previouslyOpened.filter((id) => findItemById(treeItems.value, id));
 }
 
 // Load namespaces for a warehouse

--- a/src/components/WarehousesNavigationTree.vue
+++ b/src/components/WarehousesNavigationTree.vue
@@ -586,13 +586,29 @@ async function loadNamespacesForWarehouse(item: TreeItem) {
     const response = await functions.listNamespaces(item.warehouseId, undefined, undefined, false);
 
     if (response && response.namespaces) {
+      // Build a map of existing children to preserve their loaded state
+      const existingChildrenById = new Map<string, TreeItem>();
+      if (item.children) {
+        for (const child of item.children) {
+          existingChildrenById.set(child.id, child);
+        }
+      }
+
       const namespaceItems: TreeItem[] = response.namespaces.map((ns: string[]) => {
         // ns is already an array like ["f-inance"] or ["finance", "sub"]
         const namespacePath = ns.join('.');
         const displayName = ns[ns.length - 1]; // Display only the last segment
+        const childId = `namespace-${item.warehouseId}-${namespacePath}`;
+
+        // Reuse existing node to preserve its loaded children
+        const existing = existingChildrenById.get(childId);
+        if (existing) {
+          existing.name = displayName;
+          return existing;
+        }
 
         return {
-          id: `namespace-${item.warehouseId}-${namespacePath}`,
+          id: childId,
           name: displayName,
           type: 'namespace' as const,
           warehouseId: item.warehouseId,
@@ -640,6 +656,15 @@ async function loadChildrenForNamespace(item: TreeItem) {
   try {
     const apiNamespace = namespacePathToApiFormat(item.namespaceId);
 
+    // Build a map of existing children so we can preserve their loaded state (e.g. expanded
+    // sub-namespaces that already have their tables/views loaded).
+    const existingChildrenById = new Map<string, TreeItem>();
+    if (item.children) {
+      for (const child of item.children) {
+        existingChildrenById.set(child.id, child);
+      }
+    }
+
     // Load sub-namespaces, tables and views in parallel
     const [namespacesResponse, tablesResponse, viewsResponse] = await Promise.all([
       functions.listNamespaces(item.warehouseId, apiNamespace, undefined, false),
@@ -655,16 +680,24 @@ async function loadChildrenForNamespace(item: TreeItem) {
         // API returns full namespace path, not relative
         const subNamespacePath = ns.join('.');
         const displayName = ns[ns.length - 1];
+        const childId = `namespace-${item.warehouseId}-${subNamespacePath}`;
 
-        children.push({
-          id: `namespace-${item.warehouseId}-${subNamespacePath}`,
-          name: displayName,
-          type: 'namespace',
-          warehouseId: item.warehouseId,
-          namespaceId: subNamespacePath,
-          children: [],
-          loaded: false,
-        });
+        // Reuse existing node to preserve its loaded children (tables/views)
+        const existing = existingChildrenById.get(childId);
+        if (existing) {
+          existing.name = displayName;
+          children.push(existing);
+        } else {
+          children.push({
+            id: childId,
+            name: displayName,
+            type: 'namespace',
+            warehouseId: item.warehouseId,
+            namespaceId: subNamespacePath,
+            children: [],
+            loaded: false,
+          });
+        }
       });
     }
 

--- a/src/components/WarehousesNavigationTree.vue
+++ b/src/components/WarehousesNavigationTree.vue
@@ -557,10 +557,21 @@ async function refreshWarehouses() {
   // Reload warehouse list from server
   await loadWarehouses();
 
-  // Sort opened nodes by depth (parents first) so children are reachable after parent loads
-  const sorted = previouslyOpened.sort(
-    (a, b) => (a.match(/::/g) || []).length - (b.match(/::/g) || []).length,
-  );
+  // Sort opened nodes by depth (parents first) so children are reachable after parent loads.
+  // IDs are like "warehouse-<uuid>" or "namespace-<uuid>-ns.sub.child".
+  // Depth: warehouses = 0, namespaces = 1 + number of dots in the namespace portion.
+  function nodeDepth(id: string): number {
+    if (id.startsWith('warehouse-')) return 0;
+    if (id.startsWith('namespace-')) {
+      // Extract namespace path after "namespace-<uuid>-"
+      const parts = id.split('-');
+      // parts: ["namespace", ...uuid parts (5), namespacePath...]
+      const nsPart = parts.slice(6).join('-');
+      return 1 + (nsPart.match(/\./g) || []).length;
+    }
+    return 999; // tables/views shouldn't be in opened list
+  }
+  const sorted = previouslyOpened.sort((a, b) => nodeDepth(a) - nodeDepth(b));
 
   // Re-expand previously opened nodes by reloading their children
   for (const nodeId of sorted) {

--- a/src/stores/visual.ts
+++ b/src/stores/visual.ts
@@ -84,6 +84,22 @@ export const useVisualStore = defineStore(
     // Key: projectId, Value: { openedItems, treeItems }
     const warehouseTreeState = ref<Record<string, { openedItems: string[]; treeItems: any[] }>>({});
 
+    // Signal to tell WarehousesNavigationTree to reload a specific node
+    // Incremented counter + context so watchers fire on every signal
+    const navTreeRefreshSignal = ref<{
+      counter: number;
+      warehouseId: string;
+      namespaceId?: string; // dot-separated path of the parent namespace whose children changed
+    }>({ counter: 0, warehouseId: '' });
+
+    function refreshNavTree(warehouseId: string, namespaceId?: string) {
+      navTreeRefreshSignal.value = {
+        counter: navTreeRefreshSignal.value.counter + 1,
+        warehouseId,
+        namespaceId,
+      };
+    }
+
     // Multi-tab SQL editor state - warehouse-specific
     // Key: warehouseId, Value: { activeTabId, tabs[] }
     const warehouseSqlData = ref<Record<string, WarehouseSqlData>>({});
@@ -333,6 +349,8 @@ export const useVisualStore = defineStore(
       dismissSearchOnClick,
       requestedNamespaceTab,
       warehouseTreeState,
+      navTreeRefreshSignal,
+      refreshNavTree,
       policyBuilderDraft,
       policyEditorText,
       projectList,


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(ui): navigation tree auto-updates on namespace/table/view create and delete
fix(ui): navigation tree auto-expands to reflect current route
fix(ui): refresh button preserves expanded tree state
fix(ui): namespace permissions GRANT button missing due to missing warehouseId prop
fix(ui): hide only chart card on statistics 403 instead of showing error snackbar
END_COMMIT_OVERRIDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation tree auto-refreshes after namespace create/delete and can be programmatically refreshed.
  * Navigation tree can auto-expand to a specified namespace path and preserves previously opened nodes across refreshes.

* **Bug Fixes**
  * API chart access restrictions (HTTP 403) are handled gracefully and shown as no-chart-data instead of an error.
  * Counts loading is treated as best-effort to avoid surfacing transient errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->