### PR TITLE
feat: add kebab actions menu to LoQE tree and search results

### DIFF
--- a/src/components/LoQEExplorer.vue
+++ b/src/components/LoQEExplorer.vue
@@ -807,6 +807,19 @@ import { useLoQEStore } from '../stores/loqe';
 import { useFunctions } from '../plugins/functions';
 import { Type } from '../common/enums';
 import type { LoQEQueryResult } from '../composables/loqe/types';
+import type {
+  TableMetadataWritable,
+  ViewMetadataWritable,
+  StructField,
+  Type as IcebergType,
+  StructType,
+  ListType,
+  MapType,
+  PartitionField,
+  SortField,
+  ViewVersion,
+  SqlViewRepresentation,
+} from '../gen/iceberg/types.gen';
 import SqlEditor from './SqlEditor.vue';
 import LoQENavigationTree from './LoQENavigationTree.vue';
 import DuckDBSettingsDialog from './DuckDBSettingsDialog.vue';
@@ -910,6 +923,10 @@ const isDDLLoading = ref(false);
 const ddlContent = ref('');
 const ddlError = ref<string | null>(null);
 const ddlTitle = ref('');
+
+// Race-condition guards: monotonically increasing request tokens
+let previewRequestToken = 0;
+let ddlRequestToken = 0;
 
 // Multi-result state (one entry per statement when running multiple queries)
 interface ResultEntry {
@@ -1278,6 +1295,7 @@ async function handlePreviewTable(item: {
   name: string;
 }) {
   const tablePath = buildTablePath(item);
+  const token = ++previewRequestToken;
   previewTablePath.value = tablePath;
   previewTitle.value = `${item.name} (${item.type})`;
   previewResult.value = null;
@@ -1287,11 +1305,15 @@ async function handlePreviewTable(item: {
 
   try {
     const result = await loqe.query(`SELECT * FROM ${tablePath} LIMIT 50`);
+    if (token !== previewRequestToken) return; // stale response
     previewResult.value = result;
   } catch (err: any) {
+    if (token !== previewRequestToken) return;
     previewError.value = err?.message || 'Failed to load preview';
   } finally {
-    isPreviewLoading.value = false;
+    if (token === previewRequestToken) {
+      isPreviewLoading.value = false;
+    }
   }
 }
 
@@ -1309,46 +1331,77 @@ function insertPreviewQuery() {
   showPreviewDialog.value = false;
 }
 
-function copyPreviewPath() {
+async function copyPreviewPath() {
   if (!previewTablePath.value) return;
-  navigator.clipboard.writeText(previewTablePath.value);
+  await copyToClipboard(previewTablePath.value, 'Path copied to clipboard');
+}
+
+// ── DDL / Copy Path handlers ──────────────────────────────────────────
+
+/** Shared clipboard helper with textarea fallback for insecure contexts. */
+async function copyToClipboard(text: string, successMsg: string) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    try {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    } catch {
+      visualStore.setSnackbarMsg({
+        function: 'copyFailed',
+        text: 'Failed to copy to clipboard',
+        ttl: 3000,
+        ts: Date.now(),
+        type: Type.ERROR,
+      });
+      return;
+    }
+  }
   visualStore.setSnackbarMsg({
-    function: 'copyPath',
-    text: 'Path copied to clipboard',
+    function: 'copy',
+    text: successMsg,
     ttl: 2000,
     ts: Date.now(),
     type: Type.SUCCESS,
   });
 }
 
-// ── DDL / Copy Path handlers ──────────────────────────────────────────
-
 /**
  * Serialise an Iceberg Type to its DDL string representation.
  */
-function typeToString(t: any): string {
+function typeToString(t: IcebergType): string {
   if (typeof t === 'string') return t;
-  if (t?.type === 'struct') {
-    const inner = (t.fields || [])
-      .map((f: any) => `${f.name}: ${typeToString(f.type)}${f.required ? ' NOT NULL' : ''}`)
+  if (t.type === 'struct') {
+    const st = t as StructType;
+    const inner = st.fields
+      .map((f: StructField) => `${f.name}: ${typeToString(f.type)}${f.required ? ' NOT NULL' : ''}`)
       .join(', ');
     return `struct<${inner}>`;
   }
-  if (t?.type === 'list') return `list<${typeToString(t.element)}>`;
-  if (t?.type === 'map') return `map<${typeToString(t.key)}, ${typeToString(t.value)}>`;
-  return String(t ?? 'unknown');
+  if (t.type === 'list') {
+    const lt = t as ListType;
+    return `list<${typeToString(lt.element)}>`;
+  }
+  if (t.type === 'map') {
+    const mt = t as MapType;
+    return `map<${typeToString(mt.key)}, ${typeToString(mt.value)}>`;
+  }
+  return String(t);
 }
 
-function generateTableDDL(tablePath: string, metadata: any): string {
+function generateTableDDL(tablePath: string, metadata: TableMetadataWritable): string {
   const lines: string[] = [];
   const schemaId = metadata['current-schema-id'] ?? 0;
-  const schema =
-    (metadata.schemas || []).find((s: any) => s['schema-id'] === schemaId) ||
-    (metadata.schemas || [])[0];
+  const schemas = metadata.schemas || [];
+  const schema = schemas.find((s) => (s as any)['schema-id'] === schemaId) || schemas[0];
 
   lines.push(`CREATE TABLE ${tablePath} (`);
   if (schema?.fields?.length) {
-    const cols = schema.fields.map((f: any) => {
+    const cols = schema.fields.map((f: StructField) => {
       let col = `  ${f.name} ${typeToString(f.type)}`;
       if (f.required) col += ' NOT NULL';
       if (f.doc) col += ` COMMENT '${f.doc.replace(/'/g, "''")}'`;
@@ -1360,14 +1413,13 @@ function generateTableDDL(tablePath: string, metadata: any): string {
 
   // Partition spec
   const specId = metadata['default-spec-id'] ?? 0;
-  const partSpec =
-    (metadata['partition-specs'] || []).find((s: any) => s['spec-id'] === specId) ||
-    (metadata['partition-specs'] || [])[0];
+  const partSpecs = metadata['partition-specs'] || [];
+  const partSpec = partSpecs.find((s) => (s as any)['spec-id'] === specId) || partSpecs[0];
   if (partSpec?.fields?.length) {
-    const sourceNames = schema?.fields
-      ? Object.fromEntries(schema.fields.map((f: any) => [f.id, f.name]))
+    const sourceNames: Record<number, string> = schema?.fields
+      ? Object.fromEntries(schema.fields.map((f: StructField) => [f.id, f.name]))
       : {};
-    const parts = partSpec.fields.map((pf: any) => {
+    const parts = partSpec.fields.map((pf: PartitionField) => {
       const colName = sourceNames[pf['source-id']] || `col_${pf['source-id']}`;
       return pf.transform === 'identity' ? colName : `${pf.transform}(${colName})`;
     });
@@ -1376,14 +1428,13 @@ function generateTableDDL(tablePath: string, metadata: any): string {
 
   // Sort order
   const sortId = metadata['default-sort-order-id'] ?? 0;
-  const sortOrder =
-    (metadata['sort-orders'] || []).find((s: any) => s['order-id'] === sortId) ||
-    (metadata['sort-orders'] || [])[0];
+  const sortOrders = metadata['sort-orders'] || [];
+  const sortOrder = sortOrders.find((s) => (s as any)['order-id'] === sortId) || sortOrders[0];
   if (sortOrder?.fields?.length) {
-    const sourceNames = schema?.fields
-      ? Object.fromEntries(schema.fields.map((f: any) => [f.id, f.name]))
+    const sourceNames: Record<number, string> = schema?.fields
+      ? Object.fromEntries(schema.fields.map((f: StructField) => [f.id, f.name]))
       : {};
-    const sorts = sortOrder.fields.map((sf: any) => {
+    const sorts = sortOrder.fields.map((sf: SortField) => {
       const colName = sourceNames[sf['source-id']] || `col_${sf['source-id']}`;
       const expr = sf.transform === 'identity' ? colName : `${sf.transform}(${colName})`;
       return `${expr} ${sf.direction} ${sf['null-order']}`;
@@ -1407,39 +1458,38 @@ function generateTableDDL(tablePath: string, metadata: any): string {
   return lines.join('\n') + '\n';
 }
 
-function generateViewDDL(viewPath: string, metadata: any): string {
+function generateViewDDL(viewPath: string, metadata: ViewMetadataWritable): string {
   const lines: string[] = [];
   const versionId = metadata['current-version-id'];
-  const version =
-    (metadata.versions || []).find((v: any) => v['version-id'] === versionId) ||
-    (metadata.versions || [])[0];
+  const version: ViewVersion | undefined =
+    metadata.versions.find((v) => v['version-id'] === versionId) || metadata.versions[0];
 
   // Schema
   const schemaId = version?.['schema-id'] ?? 0;
-  const schema =
-    (metadata.schemas || []).find((s: any) => s['schema-id'] === schemaId) ||
-    (metadata.schemas || [])[0];
+  const schemas = metadata.schemas || [];
+  const schema = schemas.find((s) => (s as any)['schema-id'] === schemaId) || schemas[0];
 
-  lines.push(`CREATE VIEW ${viewPath} (`);
+  // Standard CREATE VIEW: only column names in the parenthesised list
   if (schema?.fields?.length) {
-    const cols = schema.fields.map((f: any) => {
-      let col = `  ${f.name} ${typeToString(f.type)}`;
-      if (f.doc) col += ` COMMENT '${f.doc.replace(/'/g, "''")}'`;
-      return col;
-    });
-    lines.push(cols.join(',\n'));
+    const colNames = schema.fields.map((f: StructField) => `  ${f.name}`).join(',\n');
+    lines.push(`CREATE VIEW ${viewPath} (`);
+    lines.push(colNames);
+    lines.push(') AS');
+  } else {
+    lines.push(`CREATE VIEW ${viewPath} AS`);
   }
-  lines.push(') AS');
 
   // SQL representation
-  const sqlRep = version?.representations?.find((r: any) => r.type === 'sql');
+  const sqlRep: SqlViewRepresentation | undefined = version?.representations?.find(
+    (r): r is SqlViewRepresentation => r.type === 'sql',
+  );
   if (sqlRep?.sql) {
     lines.push(sqlRep.sql);
   } else {
     lines.push('-- (no SQL representation available)');
   }
 
-  // Properties
+  // Properties as comments
   if (metadata.properties && Object.keys(metadata.properties).length) {
     lines.push('');
     lines.push('-- View properties:');
@@ -1459,6 +1509,7 @@ async function handleShowDDL(item: {
   name: string;
 }) {
   const tablePath = buildTablePath(item);
+  const token = ++ddlRequestToken;
   ddlTitle.value = `${item.name} (${item.type})`;
   ddlContent.value = '';
   ddlError.value = null;
@@ -1468,6 +1519,7 @@ async function handleShowDDL(item: {
   try {
     if (item.type === 'view') {
       const result = await functions.loadView(item.warehouseId, item.namespaceId, item.name, false);
+      if (token !== ddlRequestToken) return;
       ddlContent.value = generateViewDDL(tablePath, result.metadata);
     } else {
       const result = await functions.loadTable(
@@ -1476,16 +1528,20 @@ async function handleShowDDL(item: {
         item.name,
         false,
       );
+      if (token !== ddlRequestToken) return;
       ddlContent.value = generateTableDDL(tablePath, result.metadata);
     }
   } catch (err: any) {
+    if (token !== ddlRequestToken) return;
     ddlError.value = err?.message || 'Failed to load metadata';
   } finally {
-    isDDLLoading.value = false;
+    if (token === ddlRequestToken) {
+      isDDLLoading.value = false;
+    }
   }
 }
 
-function handleCopyPath(item: {
+async function handleCopyPath(item: {
   type: string;
   warehouseId: string;
   warehouseName: string;
@@ -1493,26 +1549,12 @@ function handleCopyPath(item: {
   name: string;
 }) {
   const tablePath = buildTablePath(item);
-  navigator.clipboard.writeText(tablePath);
-  visualStore.setSnackbarMsg({
-    function: 'copyPath',
-    text: 'Path copied to clipboard',
-    ttl: 2000,
-    ts: Date.now(),
-    type: Type.SUCCESS,
-  });
+  await copyToClipboard(tablePath, 'Path copied to clipboard');
 }
 
-function copyDDLToClipboard() {
+async function copyDDLToClipboard() {
   if (!ddlContent.value) return;
-  navigator.clipboard.writeText(ddlContent.value);
-  visualStore.setSnackbarMsg({
-    function: 'copyDDL',
-    text: 'DDL copied to clipboard',
-    ttl: 2000,
-    ts: Date.now(),
-    type: Type.SUCCESS,
-  });
+  await copyToClipboard(ddlContent.value, 'DDL copied to clipboard');
 }
 
 async function handleAutoAttachWarehouse(wh: {

--- a/src/components/LoQEExplorer.vue
+++ b/src/components/LoQEExplorer.vue
@@ -98,7 +98,10 @@
             <LoQENavigationTree
               :attached-catalogs="loqe.attachedCatalogs.value"
               @item-selected="handleTreeItemSelected"
-              @attach-warehouse="handleAutoAttachWarehouse" />
+              @attach-warehouse="handleAutoAttachWarehouse"
+              @preview-table="handlePreviewTable"
+              @show-ddl="handleShowDDL"
+              @copy-path="handleCopyPath" />
           </div>
 
           <v-divider />
@@ -691,6 +694,105 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <!-- Table Preview Dialog -->
+    <v-dialog v-model="showPreviewDialog" max-width="900" scrollable>
+      <v-card>
+        <v-card-title class="d-flex align-center text-subtitle-1">
+          <v-icon size="small" class="mr-2">mdi-eye-outline</v-icon>
+          {{ previewTitle }}
+          <v-spacer />
+          <v-btn icon size="small" variant="text" @click="showPreviewDialog = false">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-card-title>
+        <v-divider />
+        <v-card-text class="pa-0" style="max-height: 500px; overflow: auto">
+          <div v-if="isPreviewLoading" class="text-center py-8">
+            <v-progress-circular indeterminate size="32" color="primary" />
+            <div class="text-caption mt-2 text-grey">Loading preview…</div>
+          </div>
+          <div v-else-if="previewError" class="pa-4">
+            <v-alert type="error" variant="tonal" density="compact">{{ previewError }}</v-alert>
+          </div>
+          <v-data-table-virtual
+            v-else-if="previewResult"
+            :headers="previewHeaders"
+            :items="previewItems"
+            :height="Math.min(400, 28 + previewItems.length * 28)"
+            density="compact"
+            fixed-header
+            class="text-caption"
+            item-height="28" />
+        </v-card-text>
+        <v-divider />
+        <v-card-actions class="px-4 py-2">
+          <span class="text-caption text-medium-emphasis">
+            <template v-if="previewResult">
+              {{ previewResult.rowCount }} row{{ previewResult.rowCount !== 1 ? 's' : '' }} &middot;
+              {{ previewResult.columns.length }} column{{
+                previewResult.columns.length !== 1 ? 's' : ''
+              }}
+              &middot; {{ previewResult.executionTimeMs.toFixed(0) }}ms
+            </template>
+          </span>
+          <v-spacer />
+          <v-btn
+            v-if="previewTablePath"
+            size="small"
+            variant="text"
+            @click="copyPreviewPath"
+            prepend-icon="mdi-content-copy">
+            Copy path
+          </v-btn>
+          <v-btn
+            v-if="previewResult"
+            size="small"
+            variant="text"
+            @click="insertPreviewQuery"
+            prepend-icon="mdi-code-tags">
+            Insert SELECT
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- DDL Dialog -->
+    <v-dialog v-model="showDDLDialog" max-width="800" scrollable>
+      <v-card>
+        <v-card-title class="d-flex align-center text-subtitle-1">
+          <v-icon size="small" class="mr-2">mdi-code-tags</v-icon>
+          {{ ddlTitle }}
+          <v-spacer />
+          <v-btn icon size="small" variant="text" @click="showDDLDialog = false">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-card-title>
+        <v-divider />
+        <v-card-text class="pa-0" style="max-height: 500px; overflow: auto">
+          <div v-if="isDDLLoading" class="text-center py-8">
+            <v-progress-circular indeterminate size="32" color="primary" />
+            <div class="text-caption mt-2 text-grey">Loading metadata…</div>
+          </div>
+          <div v-else-if="ddlError" class="pa-4">
+            <v-alert type="error" variant="tonal" density="compact">{{ ddlError }}</v-alert>
+          </div>
+          <SqlEditor v-else :model-value="ddlContent" disabled min-height="200px" placeholder="" />
+        </v-card-text>
+        <v-divider />
+        <v-card-actions class="px-4 py-2">
+          <v-spacer />
+          <v-btn
+            size="small"
+            variant="text"
+            @click="copyDDLToClipboard"
+            prepend-icon="mdi-content-copy"
+            :disabled="!ddlContent">
+            Copy DDL
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -702,6 +804,7 @@ import { useVisualStore } from '../stores/visual';
 import { useCsvDownload } from '../composables/useCsvDownload';
 import { useDuckDBSettingsStore } from '../stores/duckdbSettings';
 import { useLoQEStore } from '../stores/loqe';
+import { useFunctions } from '../plugins/functions';
 import { Type } from '../common/enums';
 import type { LoQEQueryResult } from '../composables/loqe/types';
 import SqlEditor from './SqlEditor.vue';
@@ -737,6 +840,7 @@ const appConfig = inject<any>('appConfig', { enabledAuthentication: false });
 const userStore = useUserStore();
 const visualStore = useVisualStore();
 const csvDownload = useCsvDownload();
+const functions = useFunctions();
 
 // ── LoQE composable ──────────────────────────────────────────────────
 
@@ -770,6 +874,42 @@ const renameError = ref('');
 const showCloseOtherTabsDialog = ref(false);
 const tabToKeep = ref<{ id: string; name: string } | null>(null);
 const lastExecutedTabName = ref('');
+
+// Preview dialog state
+const showPreviewDialog = ref(false);
+const isPreviewLoading = ref(false);
+const previewResult = ref<LoQEQueryResult | null>(null);
+const previewError = ref<string | null>(null);
+const previewTitle = ref('');
+const previewTablePath = ref('');
+
+const previewHeaders = computed(() => {
+  if (!previewResult.value) return [];
+  return previewResult.value.columns.map((col) => ({
+    title: col,
+    key: col,
+    sortable: false,
+  }));
+});
+
+const previewItems = computed(() => {
+  if (!previewResult.value) return [];
+  const cols = previewResult.value.columns;
+  return previewResult.value.rows.map((row) => {
+    const obj: Record<string, string> = {};
+    for (let i = 0; i < cols.length; i++) {
+      obj[cols[i]] = formatCell(row[i]);
+    }
+    return obj;
+  });
+});
+
+// DDL dialog state
+const showDDLDialog = ref(false);
+const isDDLLoading = ref(false);
+const ddlContent = ref('');
+const ddlError = ref<string | null>(null);
+const ddlTitle = ref('');
 
 // Multi-result state (one entry per statement when running multiple queries)
 interface ResultEntry {
@@ -1094,10 +1234,9 @@ function handleTreeItemSelected(item: {
     item.warehouseName &&
     item.namespaceId
   ) {
-    const nsDisplay = item.namespaceId.includes('\x1F')
-      ? item.namespaceId.split('\x1F').join('.')
-      : item.namespaceId;
-    textToInsert = `"${item.warehouseName}"."${nsDisplay}"."${item.name}"`;
+    textToInsert = buildTablePath(
+      item as { warehouseName: string; namespaceId: string; name: string },
+    );
   }
 
   if (textToInsert) {
@@ -1122,6 +1261,258 @@ async function handleFreeMemory() {
   } finally {
     isFreeing.value = false;
   }
+}
+
+function buildTablePath(item: { warehouseName: string; namespaceId: string; name: string }) {
+  const nsDisplay = item.namespaceId.includes('\x1F')
+    ? item.namespaceId.split('\x1F').join('.')
+    : item.namespaceId;
+  return `"${item.warehouseName}"."${nsDisplay}"."${item.name}"`;
+}
+
+async function handlePreviewTable(item: {
+  type: string;
+  warehouseId: string;
+  warehouseName: string;
+  namespaceId: string;
+  name: string;
+}) {
+  const tablePath = buildTablePath(item);
+  previewTablePath.value = tablePath;
+  previewTitle.value = `${item.name} (${item.type})`;
+  previewResult.value = null;
+  previewError.value = null;
+  isPreviewLoading.value = true;
+  showPreviewDialog.value = true;
+
+  try {
+    const result = await loqe.query(`SELECT * FROM ${tablePath} LIMIT 50`);
+    previewResult.value = result;
+  } catch (err: any) {
+    previewError.value = err?.message || 'Failed to load preview';
+  } finally {
+    isPreviewLoading.value = false;
+  }
+}
+
+function insertPreviewQuery() {
+  if (!previewTablePath.value) return;
+  const query = `SELECT * FROM ${previewTablePath.value} LIMIT 50`;
+  if (!sqlQuery.value) {
+    sqlQuery.value = query;
+  } else {
+    const before = sqlQuery.value.substring(0, cursorPosition.value);
+    const after = sqlQuery.value.substring(cursorPosition.value);
+    sqlQuery.value = before + query + after;
+    cursorPosition.value += query.length;
+  }
+  showPreviewDialog.value = false;
+}
+
+function copyPreviewPath() {
+  if (!previewTablePath.value) return;
+  navigator.clipboard.writeText(previewTablePath.value);
+  visualStore.setSnackbarMsg({
+    function: 'copyPath',
+    text: 'Path copied to clipboard',
+    ttl: 2000,
+    ts: Date.now(),
+    type: Type.SUCCESS,
+  });
+}
+
+// ── DDL / Copy Path handlers ──────────────────────────────────────────
+
+/**
+ * Serialise an Iceberg Type to its DDL string representation.
+ */
+function typeToString(t: any): string {
+  if (typeof t === 'string') return t;
+  if (t?.type === 'struct') {
+    const inner = (t.fields || [])
+      .map((f: any) => `${f.name}: ${typeToString(f.type)}${f.required ? ' NOT NULL' : ''}`)
+      .join(', ');
+    return `struct<${inner}>`;
+  }
+  if (t?.type === 'list') return `list<${typeToString(t.element)}>`;
+  if (t?.type === 'map') return `map<${typeToString(t.key)}, ${typeToString(t.value)}>`;
+  return String(t ?? 'unknown');
+}
+
+function generateTableDDL(tablePath: string, metadata: any): string {
+  const lines: string[] = [];
+  const schemaId = metadata['current-schema-id'] ?? 0;
+  const schema =
+    (metadata.schemas || []).find((s: any) => s['schema-id'] === schemaId) ||
+    (metadata.schemas || [])[0];
+
+  lines.push(`CREATE TABLE ${tablePath} (`);
+  if (schema?.fields?.length) {
+    const cols = schema.fields.map((f: any) => {
+      let col = `  ${f.name} ${typeToString(f.type)}`;
+      if (f.required) col += ' NOT NULL';
+      if (f.doc) col += ` COMMENT '${f.doc.replace(/'/g, "''")}'`;
+      return col;
+    });
+    lines.push(cols.join(',\n'));
+  }
+  lines.push(')');
+
+  // Partition spec
+  const specId = metadata['default-spec-id'] ?? 0;
+  const partSpec =
+    (metadata['partition-specs'] || []).find((s: any) => s['spec-id'] === specId) ||
+    (metadata['partition-specs'] || [])[0];
+  if (partSpec?.fields?.length) {
+    const sourceNames = schema?.fields
+      ? Object.fromEntries(schema.fields.map((f: any) => [f.id, f.name]))
+      : {};
+    const parts = partSpec.fields.map((pf: any) => {
+      const colName = sourceNames[pf['source-id']] || `col_${pf['source-id']}`;
+      return pf.transform === 'identity' ? colName : `${pf.transform}(${colName})`;
+    });
+    lines.push(`PARTITIONED BY (${parts.join(', ')})`);
+  }
+
+  // Sort order
+  const sortId = metadata['default-sort-order-id'] ?? 0;
+  const sortOrder =
+    (metadata['sort-orders'] || []).find((s: any) => s['order-id'] === sortId) ||
+    (metadata['sort-orders'] || [])[0];
+  if (sortOrder?.fields?.length) {
+    const sourceNames = schema?.fields
+      ? Object.fromEntries(schema.fields.map((f: any) => [f.id, f.name]))
+      : {};
+    const sorts = sortOrder.fields.map((sf: any) => {
+      const colName = sourceNames[sf['source-id']] || `col_${sf['source-id']}`;
+      const expr = sf.transform === 'identity' ? colName : `${sf.transform}(${colName})`;
+      return `${expr} ${sf.direction} ${sf['null-order']}`;
+    });
+    lines.push(`SORTED BY (${sorts.join(', ')})`);
+  }
+
+  // Location
+  if (metadata.location) {
+    lines.push(`LOCATION '${metadata.location}'`);
+  }
+
+  // Properties
+  if (metadata.properties && Object.keys(metadata.properties).length) {
+    const props = Object.entries(metadata.properties)
+      .map(([k, v]) => `  '${k}' = '${String(v).replace(/'/g, "''")}'`)
+      .join(',\n');
+    lines.push(`TBLPROPERTIES (\n${props}\n)`);
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+function generateViewDDL(viewPath: string, metadata: any): string {
+  const lines: string[] = [];
+  const versionId = metadata['current-version-id'];
+  const version =
+    (metadata.versions || []).find((v: any) => v['version-id'] === versionId) ||
+    (metadata.versions || [])[0];
+
+  // Schema
+  const schemaId = version?.['schema-id'] ?? 0;
+  const schema =
+    (metadata.schemas || []).find((s: any) => s['schema-id'] === schemaId) ||
+    (metadata.schemas || [])[0];
+
+  lines.push(`CREATE VIEW ${viewPath} (`);
+  if (schema?.fields?.length) {
+    const cols = schema.fields.map((f: any) => {
+      let col = `  ${f.name} ${typeToString(f.type)}`;
+      if (f.doc) col += ` COMMENT '${f.doc.replace(/'/g, "''")}'`;
+      return col;
+    });
+    lines.push(cols.join(',\n'));
+  }
+  lines.push(') AS');
+
+  // SQL representation
+  const sqlRep = version?.representations?.find((r: any) => r.type === 'sql');
+  if (sqlRep?.sql) {
+    lines.push(sqlRep.sql);
+  } else {
+    lines.push('-- (no SQL representation available)');
+  }
+
+  // Properties
+  if (metadata.properties && Object.keys(metadata.properties).length) {
+    lines.push('');
+    lines.push('-- View properties:');
+    for (const [k, v] of Object.entries(metadata.properties)) {
+      lines.push(`--   ${k} = ${v}`);
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+async function handleShowDDL(item: {
+  type: string;
+  warehouseId: string;
+  warehouseName: string;
+  namespaceId: string;
+  name: string;
+}) {
+  const tablePath = buildTablePath(item);
+  ddlTitle.value = `${item.name} (${item.type})`;
+  ddlContent.value = '';
+  ddlError.value = null;
+  isDDLLoading.value = true;
+  showDDLDialog.value = true;
+
+  try {
+    if (item.type === 'view') {
+      const result = await functions.loadView(item.warehouseId, item.namespaceId, item.name, false);
+      ddlContent.value = generateViewDDL(tablePath, result.metadata);
+    } else {
+      const result = await functions.loadTable(
+        item.warehouseId,
+        item.namespaceId,
+        item.name,
+        false,
+      );
+      ddlContent.value = generateTableDDL(tablePath, result.metadata);
+    }
+  } catch (err: any) {
+    ddlError.value = err?.message || 'Failed to load metadata';
+  } finally {
+    isDDLLoading.value = false;
+  }
+}
+
+function handleCopyPath(item: {
+  type: string;
+  warehouseId: string;
+  warehouseName: string;
+  namespaceId: string;
+  name: string;
+}) {
+  const tablePath = buildTablePath(item);
+  navigator.clipboard.writeText(tablePath);
+  visualStore.setSnackbarMsg({
+    function: 'copyPath',
+    text: 'Path copied to clipboard',
+    ttl: 2000,
+    ts: Date.now(),
+    type: Type.SUCCESS,
+  });
+}
+
+function copyDDLToClipboard() {
+  if (!ddlContent.value) return;
+  navigator.clipboard.writeText(ddlContent.value);
+  visualStore.setSnackbarMsg({
+    function: 'copyDDL',
+    text: 'DDL copied to clipboard',
+    ttl: 2000,
+    ts: Date.now(),
+    type: Type.SUCCESS,
+  });
 }
 
 async function handleAutoAttachWarehouse(wh: {

--- a/src/components/LoQENavigationTree.vue
+++ b/src/components/LoQENavigationTree.vue
@@ -139,6 +139,39 @@
                 title="Insert into SQL editor">
                 <v-icon size="small">mdi-plus-circle-outline</v-icon>
               </v-btn>
+              <v-menu location="bottom end">
+                <template #activator="{ props: menuProps }">
+                  <v-btn
+                    v-bind="menuProps"
+                    icon
+                    size="x-small"
+                    variant="text"
+                    @click.stop
+                    title="More actions">
+                    <v-icon size="small">mdi-dots-vertical</v-icon>
+                  </v-btn>
+                </template>
+                <v-list density="compact" class="pa-1" min-width="160">
+                  <v-list-item
+                    density="compact"
+                    @click="handlePreviewSearchResult(result)"
+                    prepend-icon="mdi-eye-outline">
+                    <v-list-item-title class="text-caption">Preview data</v-list-item-title>
+                  </v-list-item>
+                  <v-list-item
+                    density="compact"
+                    @click="handleShowDDLSearchResult(result)"
+                    prepend-icon="mdi-code-tags">
+                    <v-list-item-title class="text-caption">Show DDL</v-list-item-title>
+                  </v-list-item>
+                  <v-list-item
+                    density="compact"
+                    @click="handleCopyPathSearchResult(result)"
+                    prepend-icon="mdi-content-copy">
+                    <v-list-item-title class="text-caption">Copy path</v-list-item-title>
+                  </v-list-item>
+                </v-list>
+              </v-menu>
             </template>
           </v-list-item>
         </v-list>
@@ -264,6 +297,43 @@
               <v-icon size="small">mdi-plus-circle-outline</v-icon>
             </v-btn>
 
+            <!-- Kebab menu for tables/views -->
+            <v-menu v-if="item.type === 'table' || item.type === 'view'" location="bottom end">
+              <template #activator="{ props: menuProps }">
+                <v-btn
+                  v-bind="menuProps"
+                  icon
+                  size="x-small"
+                  variant="text"
+                  class="tree-item-insert-btn"
+                  :style="{ opacity: hoveredItem === item.id ? 1 : 0 }"
+                  @click.stop
+                  title="More actions">
+                  <v-icon size="small">mdi-dots-vertical</v-icon>
+                </v-btn>
+              </template>
+              <v-list density="compact" class="pa-1" min-width="160">
+                <v-list-item
+                  density="compact"
+                  @click="handlePreview(item)"
+                  prepend-icon="mdi-eye-outline">
+                  <v-list-item-title class="text-caption">Preview data</v-list-item-title>
+                </v-list-item>
+                <v-list-item
+                  density="compact"
+                  @click="handleShowDDL(item)"
+                  prepend-icon="mdi-code-tags">
+                  <v-list-item-title class="text-caption">Show DDL</v-list-item-title>
+                </v-list-item>
+                <v-list-item
+                  density="compact"
+                  @click="handleCopyPath(item)"
+                  prepend-icon="mdi-content-copy">
+                  <v-list-item-title class="text-caption">Copy path</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
+
             <!-- Insert button for fields -->
             <v-btn
               v-if="item.type === 'field'"
@@ -318,6 +388,39 @@ const emit = defineEmits<{
   (
     e: 'attach-warehouse',
     warehouse: { warehouseId: string; warehouseName: string; catalogUrl: string },
+  ): void;
+  /** User clicked the eye icon to preview table/view data */
+  (
+    e: 'preview-table',
+    item: {
+      type: string;
+      warehouseId: string;
+      warehouseName: string;
+      namespaceId: string;
+      name: string;
+    },
+  ): void;
+  /** User clicked Show DDL */
+  (
+    e: 'show-ddl',
+    item: {
+      type: string;
+      warehouseId: string;
+      warehouseName: string;
+      namespaceId: string;
+      name: string;
+    },
+  ): void;
+  /** User clicked Copy path */
+  (
+    e: 'copy-path',
+    item: {
+      type: string;
+      warehouseId: string;
+      warehouseName: string;
+      namespaceId: string;
+      name: string;
+    },
   ): void;
 }>();
 
@@ -525,6 +628,36 @@ async function handleSearchResultClick(result: (typeof searchResults.value)[0]) 
 
 function insertSearchResult(result: (typeof searchResults.value)[0]) {
   emit('item-selected', {
+    type: result.type,
+    warehouseId: result.warehouseId,
+    warehouseName: result.warehouseName,
+    namespaceId: result.namespaceId,
+    name: result.name,
+  });
+}
+
+function handlePreviewSearchResult(result: (typeof searchResults.value)[0]) {
+  emit('preview-table', {
+    type: result.type,
+    warehouseId: result.warehouseId,
+    warehouseName: result.warehouseName,
+    namespaceId: result.namespaceId,
+    name: result.name,
+  });
+}
+
+function handleShowDDLSearchResult(result: (typeof searchResults.value)[0]) {
+  emit('show-ddl', {
+    type: result.type,
+    warehouseId: result.warehouseId,
+    warehouseName: result.warehouseName,
+    namespaceId: result.namespaceId,
+    name: result.name,
+  });
+}
+
+function handleCopyPathSearchResult(result: (typeof searchResults.value)[0]) {
+  emit('copy-path', {
     type: result.type,
     warehouseId: result.warehouseId,
     warehouseName: result.warehouseName,
@@ -1091,6 +1224,39 @@ function handleInsertPath(item: TreeItem) {
 function handleInsertField(item: TreeItem) {
   emit('item-selected', {
     type: 'field',
+    warehouseId: item.warehouseId,
+    warehouseName: item.warehouseName || '',
+    namespaceId: item.namespaceId,
+    name: item.name,
+  });
+}
+
+function handlePreview(item: TreeItem) {
+  if (!item.namespaceId) return;
+  emit('preview-table', {
+    type: item.type,
+    warehouseId: item.warehouseId,
+    warehouseName: item.warehouseName || '',
+    namespaceId: item.namespaceId,
+    name: item.name,
+  });
+}
+
+function handleShowDDL(item: TreeItem) {
+  if (!item.namespaceId) return;
+  emit('show-ddl', {
+    type: item.type,
+    warehouseId: item.warehouseId,
+    warehouseName: item.warehouseName || '',
+    namespaceId: item.namespaceId,
+    name: item.name,
+  });
+}
+
+function handleCopyPath(item: TreeItem) {
+  if (!item.namespaceId) return;
+  emit('copy-path', {
+    type: item.type,
     warehouseId: item.warehouseId,
     warehouseName: item.warehouseName || '',
     namespaceId: item.namespaceId,


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat(ui): add kebab actions menu to LoQE tree and search results
END_COMMIT_OVERRIDE

## Changes

- Replace standalone eye (preview) button with **⋮ kebab menu** on table/view nodes in the LoQE object browser tree
- Menu actions: **Preview data**, **Show DDL**, **Copy path**
- Same kebab menu added to **search results** alongside the existing `+` insert button
- DDL dialog uses a **read-only SqlEditor** for SQL syntax highlighting
- DDL generated client-side from Iceberg REST API metadata (`loadTable`/`loadView`) — supports columns, partition specs, sort orders, properties, and location
- Copy path copies the quoted identifier (e.g. `"wh"."ns"."table"`) to clipboard with a snackbar confirmation
- Preview dialog gains a **Copy path** button next to Insert SELECT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table preview: view sample rows with options to copy the table path or insert a SELECT ... LIMIT 50 into the SQL editor.
  * DDL viewer: display and copy generated schema (tables/views).
  * "More actions" menu: quick access to Preview Data, Show DDL, and Copy Path for tables, views, and search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->