### PR TITLE
fix: always show snackbar on 403 errors

### DIFF
--- a/src/plugins/functions.ts
+++ b/src/plugins/functions.ts
@@ -1,6 +1,6 @@
 import { inject } from 'vue';
 import { permissionActions } from '@/common/permissionActions';
-import { logError, isClientError, isForbiddenError, isNotFoundError } from '@/common/errorUtils';
+import { logError, isClientError, isNotFoundError } from '@/common/errorUtils';
 import {
   NamespaceResponse,
   SearchTabularRequest,

--- a/src/plugins/functions.ts
+++ b/src/plugins/functions.ts
@@ -190,9 +190,10 @@ export function handleError(error: any, functionError: Error | string, notify?: 
       logError('handleError', error);
     }
 
-    // 403/404 are handled inline by the UI (v-alert, router.replace to parent, etc.).
-    // Don't show snackbar unless the caller explicitly requested notification (notify=true).
-    if ((isForbiddenError(error) || isNotFoundError(error)) && notify !== true) {
+    // 403 errors always show a snackbar so the user knows they lack permission.
+    // 404 errors are handled inline by the UI (v-alert, router.replace to parent, etc.)
+    // and don't show a snackbar unless the caller explicitly requested notification (notify=true).
+    if (isNotFoundError(error) && notify !== true) {
       return;
     }
 


### PR DESCRIPTION
403 Forbidden errors now always display a snackbar notification so the user knows they lack permission. Previously, 403 errors were silently suppressed unless the caller explicitly passed `notify=true`.

404 errors remain silently handled by the UI (router redirect, v-alert) unless `notify=true` is explicitly passed.

This re-applies the fix from #112 (which was merged before CI completed and then reverted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Forbidden access errors (HTTP 403) now display error notifications to users instead of being silently ignored, improving transparency and user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->