### PR TITLE
fix: preload storage cred type

### DIFF
--- a/openapi/management-open-api.yaml
+++ b/openapi/management-open-api.yaml
@@ -3643,6 +3643,13 @@ components:
               type: string
               enum:
                 - azure-system-identity
+    AzCredentialType:
+      type: string
+      description: The type of Azure credential.
+      enum:
+        - client-credentials
+        - shared-access-key
+        - azure-system-identity
     BootstrapRequest:
       type: object
       required:
@@ -4343,6 +4350,12 @@ components:
               "universe_domain": "googleapis.com"
             }
         ```
+    GcsCredentialType:
+      type: string
+      description: The type of GCS credential.
+      enum:
+        - service-account-key
+        - gcp-system-identity
     GcsProfile:
       type: object
       required:
@@ -4843,6 +4856,15 @@ components:
         status:
           $ref: '#/components/schemas/WarehouseStatus'
           description: Whether the warehouse is active.
+        storage-credential-type:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/StorageCredentialType'
+              description: |-
+                Best-effort indicator of the storage credential type. When present it
+                reflects the detected credential kind; when absent the warehouse may
+                either have no credential configured or the secret lookup may have
+                failed. Does not contain secret values.
         storage-profile:
           $ref: '#/components/schemas/StorageProfile'
           description: Storage profile used for the warehouse.
@@ -5172,7 +5194,7 @@ components:
     LakekeeperServerAction:
       oneOf:
         - type: object
-          description: Can create projects on the server.
+          description: Can create items inside the server (can create Warehouses).
           required:
             - action
           properties:
@@ -6477,6 +6499,13 @@ components:
                   type: string
                   enum:
                     - cloudflare-r2
+    S3CredentialType:
+      type: string
+      description: The type of S3 credential.
+      enum:
+        - access-key
+        - aws-system-identity
+        - cloudflare-r2
     S3Flavor:
       type: string
       enum:
@@ -7035,6 +7064,52 @@ components:
             }"#).unwrap();
             ```
       description: Storage secret for a warehouse.
+    StorageCredentialType:
+      oneOf:
+        - type: object
+          description: S3 credential type
+          required:
+            - credential-type
+            - type
+          properties:
+            credential-type:
+              $ref: '#/components/schemas/S3CredentialType'
+              description: S3 credential type
+            type:
+              type: string
+              enum:
+                - s3
+        - type: object
+          description: Azure credential type
+          required:
+            - credential-type
+            - type
+          properties:
+            credential-type:
+              $ref: '#/components/schemas/AzCredentialType'
+              description: Azure credential type
+            type:
+              type: string
+              enum:
+                - az
+        - type: object
+          description: GCS credential type
+          required:
+            - credential-type
+            - type
+          properties:
+            credential-type:
+              $ref: '#/components/schemas/GcsCredentialType'
+              description: GCS credential type
+            type:
+              type: string
+              enum:
+                - gcs
+      description: |-
+        The type of storage credential configured for a warehouse, without secret values.
+
+        This is returned in API responses so clients know which credential type
+        was selected (e.g. to restore radio button state in the UI).
     StorageLayout:
       oneOf:
         - type: object
@@ -7629,7 +7704,7 @@ components:
             Storage profile to use for the warehouse.
             The new profile must point to the same location as the existing profile
             to avoid data loss. For S3 this means that you may not change the
-            bucket, key prefix, or region.
+            bucket or key prefix. The region may only be changed if an endpoint is set.
     User:
       type: object
       description: User of the catalog

--- a/src/components/WarehouseAddDialog.vue
+++ b/src/components/WarehouseAddDialog.vue
@@ -174,16 +174,24 @@
             <span v-if="props.objectType !== ObjectType.DELETION_PROFILE">
               <v-tabs v-model="storageCredentialType" color="primary" :disabled="!emptyWarehouse">
                 <v-tab value="S3">
-                  <v-icon start>mdi-aws</v-icon>
-                  S3
+                  <v-icon start color="orange">mdi-aws</v-icon>
+                  AWS S3
                 </v-tab>
                 <v-tab value="GCS">
-                  <v-icon start>mdi-google-cloud</v-icon>
+                  <v-icon start color="info">mdi-google-cloud</v-icon>
                   GCS
                 </v-tab>
                 <v-tab value="AZURE">
-                  <v-icon start>mdi-microsoft-azure</v-icon>
+                  <v-icon start color="primary">mdi-microsoft-azure</v-icon>
                   Azure
+                </v-tab>
+                <v-tab value="R2">
+                  <v-img :src="cfIcon" width="20" height="20" class="mr-2" />
+                  R2
+                </v-tab>
+                <v-tab value="S3_COMPAT">
+                  <v-icon start color="primary">mdi-bucket-outline</v-icon>
+                  S3 Compatible
                 </v-tab>
               </v-tabs>
 
@@ -193,6 +201,7 @@
                     :credentials-only="emptyWarehouse"
                     :intent="intent"
                     :object-type="objectType"
+                    s3-variant="aws"
                     :warehouse-object="warehouseObjectS3"
                     @submit="createWarehouse"
                     @update-credentials="newCredentials"
@@ -219,6 +228,30 @@
                     @submit="createWarehouse"
                     @update-credentials="newCredentials"
                     @update-profile="newProfile"></WarehouseStorageAzure>
+                </v-tabs-window-item>
+
+                <v-tabs-window-item value="R2">
+                  <WarehouseStorageS3
+                    :credentials-only="emptyWarehouse"
+                    :intent="intent"
+                    :object-type="objectType"
+                    s3-variant="cloudflare-r2"
+                    :warehouse-object="warehouseObjectR2"
+                    @submit="createWarehouse"
+                    @update-credentials="newCredentials"
+                    @update-profile="newProfile"></WarehouseStorageS3>
+                </v-tabs-window-item>
+
+                <v-tabs-window-item value="S3_COMPAT">
+                  <WarehouseStorageS3
+                    :credentials-only="emptyWarehouse"
+                    :intent="intent"
+                    :object-type="objectType"
+                    s3-variant="s3-compat"
+                    :warehouse-object="warehouseObjectS3Compat"
+                    @submit="createWarehouse"
+                    @update-credentials="newCredentials"
+                    @update-profile="newProfile"></WarehouseStorageS3>
                 </v-tabs-window-item>
               </v-tabs-window>
             </span>
@@ -252,6 +285,7 @@ import WarehouseStorageS3 from './WarehouseStorageS3.vue';
 import WarehouseStorageAzure from './WarehouseStorageAzure.vue';
 import WarehouseStorageGCS from './WarehouseStorageGCS.vue';
 import WarehouseStorageJSON from './WarehouseStorageJSON.vue';
+import cfIcon from '@/assets/cf.svg';
 
 import {
   CreateWarehouseRequest,
@@ -325,6 +359,43 @@ const warehouseObjectS3 = reactive<WarehousObject>({
     region: '',
     'remote-signing-enabled': true,
     'sts-enabled': false,
+    flavor: 'aws',
+  },
+  'storage-credential': {
+    type: 's3',
+    'aws-access-key-id': '',
+    'aws-secret-access-key': '',
+    'credential-type': 'access-key',
+  },
+});
+
+const warehouseObjectR2 = reactive<WarehousObject>({
+  'storage-profile': {
+    type: 's3',
+    bucket: '',
+    region: '',
+    'remote-signing-enabled': true,
+    'sts-enabled': true,
+    flavor: 's3-compat',
+  },
+  'storage-credential': {
+    type: 's3',
+    'credential-type': 'cloudflare-r2',
+    'access-key-id': '',
+    'secret-access-key': '',
+    'account-id': '',
+    token: '',
+  },
+});
+
+const warehouseObjectS3Compat = reactive<WarehousObject>({
+  'storage-profile': {
+    type: 's3',
+    bucket: '',
+    region: 'local',
+    'remote-signing-enabled': true,
+    'sts-enabled': false,
+    flavor: 's3-compat',
   },
   'storage-credential': {
     type: 's3',
@@ -383,8 +454,15 @@ async function createWarehouse(
   try {
     if (warehouseObject['storage-profile'].type === 'gcs')
       Object.assign(warehouseObjectGCS, warehouseObject);
-    if (warehouseObject['storage-profile'].type === 's3')
-      Object.assign(warehouseObjectS3, warehouseObject);
+    if (warehouseObject['storage-profile'].type === 's3') {
+      if (storageCredentialType.value === 'R2') {
+        Object.assign(warehouseObjectR2, warehouseObject);
+      } else if (storageCredentialType.value === 'S3_COMPAT') {
+        Object.assign(warehouseObjectS3Compat, warehouseObject);
+      } else {
+        Object.assign(warehouseObjectS3, warehouseObject);
+      }
+    }
     if (warehouseObject['storage-profile'].type === 'az')
       Object.assign(warehouseObjectAz, warehouseObject);
 
@@ -437,10 +515,43 @@ async function createWarehouse(
   }
 }
 
+function cleanS3Credential(cred: any): StorageCredential {
+  if (cred?.type !== 's3') return cred;
+  const credType = cred['credential-type'];
+  if (credType === 'cloudflare-r2') {
+    return {
+      type: 's3',
+      'credential-type': 'cloudflare-r2',
+      'access-key-id': cred['access-key-id'] ?? '',
+      'secret-access-key': cred['secret-access-key'] ?? '',
+      token: cred.token ?? '',
+      'account-id': cred['account-id'] ?? '',
+    } as StorageCredential;
+  }
+  if (credType === 'aws-system-identity') {
+    return {
+      type: 's3',
+      'credential-type': 'aws-system-identity',
+      'external-id': cred['external-id'] || null,
+    } as StorageCredential;
+  }
+  return {
+    type: 's3',
+    'credential-type': 'access-key',
+    'aws-access-key-id': cred['aws-access-key-id'] ?? '',
+    'aws-secret-access-key': cred['aws-secret-access-key'] ?? '',
+    'external-id': cred['external-id'] || null,
+  } as StorageCredential;
+}
+
 async function createWarehouseJSON(wh: CreateWarehouseRequest) {
   try {
     creatingWarehouse.value = true;
-    const res: any = await functions.createWarehouse(wh, true);
+    const cleaned = {
+      ...wh,
+      'storage-credential': cleanS3Credential(wh['storage-credential']),
+    };
+    const res: any = await functions.createWarehouse(cleaned, true);
 
     if (res.status === 400) throw new Error(res.message);
 
@@ -460,6 +571,16 @@ async function preloadWarehouseJSON(wh: CreateWarehouseRequest) {
     const type = wh['storage-profile'].type;
     if (type === 'adls') {
       storageCredentialType.value = 'AZURE';
+    } else if (type === 's3') {
+      const credType = wh['storage-credential']?.['credential-type'];
+      const flavor = wh['storage-profile']?.flavor;
+      if (credType === 'cloudflare-r2') {
+        storageCredentialType.value = 'R2';
+      } else if (flavor === 's3-compat') {
+        storageCredentialType.value = 'S3_COMPAT';
+      } else {
+        storageCredentialType.value = 'S3';
+      }
     } else {
       storageCredentialType.value = type.toUpperCase();
     }
@@ -468,11 +589,21 @@ async function preloadWarehouseJSON(wh: CreateWarehouseRequest) {
         'storage-profile': wh['storage-profile'],
         'storage-credential': wh['storage-credential'],
       });
-    if (wh['storage-profile'].type === 's3')
-      Object.assign(warehouseObjectS3, {
+    if (wh['storage-profile'].type === 's3') {
+      const credType = wh['storage-credential']?.['credential-type'];
+      const flavor = wh['storage-profile']?.flavor;
+      const data = {
         'storage-profile': wh['storage-profile'],
         'storage-credential': wh['storage-credential'],
-      });
+      };
+      if (credType === 'cloudflare-r2') {
+        Object.assign(warehouseObjectR2, data);
+      } else if (flavor === 's3-compat') {
+        Object.assign(warehouseObjectS3Compat, data);
+      } else {
+        Object.assign(warehouseObjectS3, data);
+      }
+    }
     if (wh['storage-profile'].type === 'adls')
       Object.assign(warehouseObjectAz, {
         'storage-profile': wh['storage-profile'],
@@ -515,10 +646,25 @@ onMounted(() => {
     const credType = props.warehouse['storage-credential-type'];
 
     if (props.warehouse['storage-profile'].type === 's3') {
-      storageCredentialType.value = 'S3';
-      Object.assign(warehouseObjectS3, props.warehouse);
-      if (credType && credType.type === 's3') {
-        warehouseObjectS3['storage-credential']['credential-type'] = credType['credential-type'];
+      const s3CredType = credType && credType.type === 's3' ? credType['credential-type'] : null;
+
+      if (s3CredType === 'cloudflare-r2') {
+        storageCredentialType.value = 'R2';
+        Object.assign(warehouseObjectR2, props.warehouse);
+        warehouseObjectR2['storage-credential']['credential-type'] = 'cloudflare-r2';
+      } else if (
+        s3CredType === 'access-key' &&
+        props.warehouse['storage-profile'].flavor === 's3-compat'
+      ) {
+        storageCredentialType.value = 'S3_COMPAT';
+        Object.assign(warehouseObjectS3Compat, props.warehouse);
+        warehouseObjectS3Compat['storage-credential']['credential-type'] = 'access-key';
+      } else {
+        storageCredentialType.value = 'S3';
+        Object.assign(warehouseObjectS3, props.warehouse);
+        if (s3CredType) {
+          warehouseObjectS3['storage-credential']['credential-type'] = s3CredType;
+        }
       }
     }
 

--- a/src/components/WarehouseAddDialog.vue
+++ b/src/components/WarehouseAddDialog.vue
@@ -279,7 +279,7 @@
 
 <script lang="ts" setup>
 import { reactive, ref, watch, computed, onMounted } from 'vue';
-import { useFunctions } from '../plugins/functions';
+import { useFunctions, handleError } from '../plugins/functions';
 import { useVisualStore } from '../stores/visual';
 import WarehouseStorageS3 from './WarehouseStorageS3.vue';
 import WarehouseStorageAzure from './WarehouseStorageAzure.vue';
@@ -293,7 +293,6 @@ import {
   GcsServiceKey,
   GetWarehouseResponse,
   StorageCredential,
-  StorageCredentialType,
   StorageProfile,
   TabularDeleteProfile,
 } from '../gen/management/types.gen';
@@ -510,8 +509,7 @@ async function createWarehouse(
     isDialogActive.value = false;
   } catch (error) {
     creatingWarehouse.value = false;
-
-    console.error(error);
+    handleError(error, 'createWarehouse', true);
   }
 }
 
@@ -560,8 +558,7 @@ async function createWarehouseJSON(wh: CreateWarehouseRequest) {
     isDialogActive.value = false;
   } catch (error) {
     creatingWarehouse.value = false;
-
-    console.error(error);
+    handleError(error, 'createWarehouseJSON', true);
   }
 }
 

--- a/src/components/WarehouseAddDialog.vue
+++ b/src/components/WarehouseAddDialog.vue
@@ -259,6 +259,7 @@ import {
   GcsServiceKey,
   GetWarehouseResponse,
   StorageCredential,
+  StorageCredentialType,
   StorageProfile,
   TabularDeleteProfile,
 } from '../gen/management/types.gen';
@@ -511,19 +512,30 @@ function newProfile(item: { profile: StorageProfile; credentials: StorageCredent
 onMounted(() => {
   if (props.warehouse) {
     emptyWarehouse.value = false;
+    const credType = props.warehouse['storage-credential-type'];
+
     if (props.warehouse['storage-profile'].type === 's3') {
       storageCredentialType.value = 'S3';
       Object.assign(warehouseObjectS3, props.warehouse);
+      if (credType && credType.type === 's3') {
+        warehouseObjectS3['storage-credential']['credential-type'] = credType['credential-type'];
+      }
     }
 
     if (props.warehouse['storage-profile'].type === 'adls') {
       storageCredentialType.value = 'AZURE';
       Object.assign(warehouseObjectAz, props.warehouse);
+      if (credType && credType.type === 'az') {
+        warehouseObjectAz['storage-credential']['credential-type'] = credType['credential-type'];
+      }
     }
 
     if (props.warehouse['storage-profile'].type === 'gcs') {
       storageCredentialType.value = 'GCS';
       Object.assign(warehouseObjectGCS, props.warehouse);
+      if (credType && credType.type === 'gcs') {
+        warehouseObjectGCS['storage-credential']['credential-type'] = credType['credential-type'];
+      }
     }
     if (
       props.objectType === ObjectType.DELETION_PROFILE &&

--- a/src/components/WarehouseManager.vue
+++ b/src/components/WarehouseManager.vue
@@ -67,7 +67,6 @@
         <td @click="navigateToWarehouse(item)" style="cursor: pointer !important">
           <span style="display: flex; align-items: center">
             <component :is="getStorageIcon(item)" />
-            <v-icon class="mr-2">mdi-database</v-icon>
             {{ item.name }}
           </span>
         </td>
@@ -115,7 +114,6 @@ import WarehouseAddDialog from './WarehouseAddDialog.vue';
 import DeleteConfirmDialog from './DeleteConfirmDialog.vue';
 
 // Import SVG assets
-import s3Icon from '@/assets/s3.svg';
 import cfIcon from '@/assets/cf.svg';
 
 const router = useRouter();
@@ -198,11 +196,7 @@ function getStorageIcon(item: GetWarehouseResponseExtended) {
     }
 
     // Generic S3
-    return h(VImg, {
-      class: 'mb-2 mr-2',
-      src: s3Icon,
-      width: 24,
-    });
+    return h(VIcon, { class: 'mr-2', color: 'primary', size: 'large' }, () => 'mdi-bucket-outline');
   }
 
   if (profile.type === 'adls') {

--- a/src/components/WarehouseStorageGCS.vue
+++ b/src/components/WarehouseStorageGCS.vue
@@ -589,6 +589,8 @@ const emitNewProfile = () => {
 onMounted(() => {
   if (props.warehouseObject) {
     Object.assign(warehouseObjectData, props.warehouseObject);
+    credentialType.value =
+      warehouseObjectData['storage-credential']['credential-type'] || 'service-account-key';
     keyString.value = JSON.stringify(
       warehouseObjectData['storage-credential']['credential-type'] === 'service-account-key'
         ? warehouseObjectData['storage-credential'].key

--- a/src/components/WarehouseStorageGCS.vue
+++ b/src/components/WarehouseStorageGCS.vue
@@ -559,28 +559,24 @@ const saveAsJson = () => {
 };
 
 const emitNewCredentials = () => {
+  const cred = warehouseObjectData['storage-credential'];
   const credentials = {
     type: 'gcs',
-    'credential-type': 'service-account-key',
-    key:
-      warehouseObjectData['storage-credential']['credential-type'] === 'service-account-key'
-        ? warehouseObjectData['storage-credential'].key
-        : undefined,
+    'credential-type': credentialType.value,
+    key: cred['credential-type'] === 'service-account-key' ? cred.key : undefined,
   } as StorageCredential;
 
   emit('updateCredentials', credentials);
 };
 
 const emitNewProfile = () => {
+  const cred = warehouseObjectData['storage-credential'];
   const newProfile = {
     profile: warehouseObjectData['storage-profile'],
     credentials: {
       type: 'gcs',
-      'credential-type': 'service-account-key',
-      key:
-        warehouseObjectData['storage-credential']['credential-type'] === 'service-account-key'
-          ? warehouseObjectData['storage-credential'].key
-          : undefined,
+      'credential-type': credentialType.value,
+      key: cred['credential-type'] === 'service-account-key' ? cred.key : undefined,
     } as StorageCredential,
   } as { profile: StorageProfile; credentials: StorageCredential };
   emit('updateProfile', newProfile);

--- a/src/components/WarehouseStorageS3.vue
+++ b/src/components/WarehouseStorageS3.vue
@@ -16,7 +16,7 @@
       </v-card-title>
       <v-card-text>
         <v-alert
-          v-if="warehouseObjectData['storage-credential']['credential-type'] === 'access-key'"
+          v-if="warehouseObjectData['storage-credential']['credential-type'] === 'access-key' && !props.s3Variant"
           type="info"
           variant="tonal"
           density="compact"
@@ -27,7 +27,7 @@
         </v-alert>
         <v-alert
           v-if="
-            warehouseObjectData['storage-credential']['credential-type'] === 'aws-system-identity'
+            warehouseObjectData['storage-credential']['credential-type'] === 'aws-system-identity' && !props.s3Variant
           "
           type="info"
           variant="tonal"
@@ -37,7 +37,7 @@
           Use IAM roles from the Lakekeeper server. Most secure for production AWS environments.
         </v-alert>
         <v-alert
-          v-if="warehouseObjectData['storage-credential']['credential-type'] === 'cloudflare-r2'"
+          v-if="warehouseObjectData['storage-credential']['credential-type'] === 'cloudflare-r2' && !props.s3Variant"
           type="info"
           variant="tonal"
           density="compact"
@@ -46,7 +46,7 @@
           Optimized for Cloudflare's S3-compatible object storage.
         </v-alert>
 
-        <v-radio-group v-model="warehouseObjectData['storage-credential']['credential-type']" row>
+        <v-radio-group v-if="!props.s3Variant" v-model="warehouseObjectData['storage-credential']['credential-type']" row>
           <v-row>
             <v-col>
               <span class="text-subtitle-2 text-grey-darken-1">Select Credential Type:</span>
@@ -74,6 +74,33 @@
                 <div class="d-flex align-center">
                   <v-img :src="cfIcon" width="20" height="20" class="mr-2"></v-img>
                   Cloudflare R2
+                </div>
+              </template>
+            </v-radio>
+          </v-row>
+        </v-radio-group>
+
+        <!-- AWS variant: show credential type toggle between access-key and system-identity -->
+        <v-radio-group v-if="props.s3Variant === 'aws'" v-model="warehouseObjectData['storage-credential']['credential-type']" row>
+          <v-row>
+            <v-col>
+              <span class="text-subtitle-2 text-grey-darken-1">Select Credential Type:</span>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-radio value="access-key" color="primary">
+              <template #label>
+                <div>
+                  <v-icon color="primary">mdi-key</v-icon>
+                  Access Key
+                </div>
+              </template>
+            </v-radio>
+            <v-radio value="aws-system-identity" color="primary">
+              <template #label>
+                <div>
+                  <v-icon color="primary">mdi-shield-key</v-icon>
+                  AWS System Identity
                 </div>
               </template>
             </v-radio>
@@ -190,7 +217,7 @@
       </v-card-title>
       <v-card-text>
         <v-row>
-          <v-col>
+          <v-col v-if="!props.s3Variant">
             <v-select
               v-model="warehouseObjectData['storage-profile'].flavor"
               item-title="name"
@@ -226,7 +253,7 @@
               :label="
                 getFieldLabel(
                   'Bucket Region',
-                  warehouseObjectData['storage-profile'].flavor === 'aws',
+                  isRegionRequired,
                 )
               "
               placeholder="eu-central-1"
@@ -516,6 +543,7 @@
           </v-expansion-panel>
         </v-expansion-panels>
 
+        <div v-if="props.s3Variant !== 'cloudflare-r2'">
         <v-divider class="my-4"></v-divider>
 
         <!-- Credential Vending Options -->
@@ -664,6 +692,8 @@
           </v-row>
         </div>
 
+        </div>
+
         <v-btn-group
           v-if="props.intent === Intent.CREATE && props.objectType === ObjectType.WAREHOUSE"
           divided>
@@ -780,10 +810,14 @@ const s3UrlDetectionModes = [
 ];
 
 const showPasswordExternalId = ref(false);
+
+export type S3Variant = 'aws' | 'cloudflare-r2' | 's3-compat';
+
 const props = defineProps<{
   credentialsOnly: boolean;
   intent: Intent;
   objectType: ObjectType;
+  s3Variant?: S3Variant;
   warehouseObject: WarehousObject | null;
 }>();
 
@@ -975,6 +1009,9 @@ const rules = {
     if (warehouseObjectData['storage-profile'].flavor === 'aws') {
       return !!value || 'Required for AWS flavor.';
     }
+    if (props.s3Variant === 'cloudflare-r2') {
+      return !!value || 'Required for Cloudflare R2.';
+    }
     return true;
   },
   // Optional field helper (for visual indication)
@@ -982,7 +1019,11 @@ const rules = {
 };
 
 // Computed properties for field requirements
-const isRegionRequired = computed(() => warehouseObjectData['storage-profile'].flavor === 'aws');
+const isRegionRequired = computed(
+  () =>
+    warehouseObjectData['storage-profile'].flavor === 'aws' ||
+    props.s3Variant === 'cloudflare-r2',
+);
 
 const areAccessKeysRequired = computed(() => {
   return warehouseObjectData['storage-credential']['credential-type'] === 'access-key';
@@ -1055,97 +1096,58 @@ const s3Flavor = [
   { name: 'S3 Compatible Storage', code: 's3-compat' },
 ];
 
+const buildCleanCredential = (): S3Credential & { type: 's3' } => {
+  const credentialType = warehouseObjectData['storage-credential']['credential-type'];
+  if (credentialType === 'cloudflare-r2') {
+    return {
+      type: 's3' as const,
+      'credential-type': 'cloudflare-r2',
+      'access-key-id': warehouseObjectData['storage-credential']['access-key-id'],
+      'secret-access-key': warehouseObjectData['storage-credential']['secret-access-key'],
+      token: warehouseObjectData['storage-credential'].token,
+      'account-id': warehouseObjectData['storage-credential']['account-id'],
+    } as S3Credential & { type: 's3' };
+  } else if (credentialType === 'aws-system-identity') {
+    return {
+      type: 's3' as const,
+      'credential-type': 'aws-system-identity',
+      'external-id': warehouseObjectData['storage-credential']['external-id'] || null,
+    } as S3Credential & { type: 's3' };
+  }
+  return {
+    type: 's3' as const,
+    'credential-type': 'access-key',
+    'aws-access-key-id': warehouseObjectData['storage-credential']['aws-access-key-id'],
+    'aws-secret-access-key': warehouseObjectData['storage-credential']['aws-secret-access-key'],
+    'external-id': warehouseObjectData['storage-credential']['external-id'] || null,
+  } as S3Credential & { type: 's3' };
+};
+
+const buildCleanData = () => {
+  return {
+    'storage-profile': warehouseObjectData['storage-profile'],
+    'storage-credential': buildCleanCredential(),
+  };
+};
+
 const handleSubmit = () => {
   shouldSaveAsJson.value = false;
-  emit('submit', warehouseObjectData, shouldSaveAsJson.value);
+  emit('submit', buildCleanData(), shouldSaveAsJson.value);
 };
 
 const saveAsJson = () => {
   shouldSaveAsJson.value = true;
-  emit('submit', warehouseObjectData, shouldSaveAsJson.value);
+  emit('submit', buildCleanData(), shouldSaveAsJson.value);
 };
 
 const emitNewCredentials = () => {
-  let credentials: StorageCredential = {
-    type: 's3',
-    'credential-type': 'access-key',
-    'aws-access-key-id': '',
-    'aws-secret-access-key': '',
-    'external-id': null,
-  }; // Initialize with default values
-  const credentialType = warehouseObjectData['storage-credential']['credential-type'];
-
-  if (credentialType === 'access-key') {
-    // Handle 'access-key' type
-    credentials = {
-      type: 's3' as const,
-      'credential-type': 'access-key',
-      'aws-access-key-id': warehouseObjectData['storage-credential']['aws-access-key-id'],
-      'aws-secret-access-key': warehouseObjectData['storage-credential']['aws-secret-access-key'],
-      'external-id': warehouseObjectData['storage-credential']['external-id'] || null, // Optional
-    } as S3Credential & { type: 's3' };
-  } else if (credentialType === 'aws-system-identity') {
-    // Handle 'aws-system-identity' type
-    credentials = {
-      type: 's3' as const,
-      'credential-type': 'aws-system-identity',
-      'external-id': warehouseObjectData['storage-credential']['external-id'] || null, // Optional
-    } as S3Credential & { type: 's3' };
-  } else if (credentialType === 'cloudflare-r2') {
-    // Handle 'cloudflare-r2' type
-    credentials = {
-      type: 's3' as const,
-      'credential-type': 'cloudflare-r2',
-      'access-key-id': warehouseObjectData['storage-credential']['access-key-id'],
-      'secret-access-key': warehouseObjectData['storage-credential']['secret-access-key'],
-      token: warehouseObjectData['storage-credential'].token,
-      'account-id': warehouseObjectData['storage-credential']['account-id'],
-    } as S3Credential & { type: 's3' };
-  }
-
-  emit('updateCredentials', credentials);
+  emit('updateCredentials', buildCleanCredential());
 };
 
 const emitNewProfile = () => {
-  let credentials: StorageCredential = {
-    type: 's3',
-    'credential-type': 'access-key',
-    'aws-access-key-id': '',
-    'aws-secret-access-key': '',
-    'external-id': null,
-  }; // Initialize with default values
-  const credentialType = warehouseObjectData['storage-credential']['credential-type'];
-
-  if (credentialType === 'access-key') {
-    // Handle 'access-key' type
-    credentials = {
-      type: 's3' as const,
-      'credential-type': 'access-key',
-      'aws-access-key-id': warehouseObjectData['storage-credential']['aws-access-key-id'],
-      'aws-secret-access-key': warehouseObjectData['storage-credential']['aws-secret-access-key'],
-      'external-id': warehouseObjectData['storage-credential']['external-id'] || null, // Optional
-    } as S3Credential & { type: 's3' };
-  } else if (credentialType === 'aws-system-identity') {
-    // Handle 'aws-system-identity' type
-    credentials = {
-      type: 's3' as const,
-      'credential-type': 'aws-system-identity',
-      'external-id': warehouseObjectData['storage-credential']['external-id'] || null, // Optional
-    } as S3Credential & { type: 's3' };
-  } else if (credentialType === 'cloudflare-r2') {
-    // Handle 'cloudflare-r2' type
-    credentials = {
-      type: 's3' as const,
-      'credential-type': 'cloudflare-r2',
-      'access-key-id': warehouseObjectData['storage-credential']['access-key-id'],
-      'secret-access-key': warehouseObjectData['storage-credential']['secret-access-key'],
-      token: warehouseObjectData['storage-credential'].token,
-      'account-id': warehouseObjectData['storage-credential']['account-id'],
-    } as S3Credential & { type: 's3' };
-  }
   const newProfile = {
     profile: warehouseObjectData['storage-profile'],
-    credentials: credentials,
+    credentials: buildCleanCredential(),
   } as { profile: StorageProfile; credentials: StorageCredential };
 
   emit('updateProfile', newProfile);
@@ -1176,6 +1178,21 @@ onMounted(() => {
         key,
         value,
       }));
+    }
+  }
+
+  // Apply variant defaults (after Object.assign so they take precedence for new warehouses)
+  if (props.s3Variant && !props.warehouseObject) {
+    if (props.s3Variant === 'aws') {
+      warehouseObjectData['storage-credential']['credential-type'] = 'access-key';
+      warehouseObjectData['storage-profile'].flavor = 'aws';
+    } else if (props.s3Variant === 'cloudflare-r2') {
+      warehouseObjectData['storage-credential']['credential-type'] = 'cloudflare-r2';
+      warehouseObjectData['storage-profile'].flavor = 's3-compat';
+      warehouseObjectData['storage-profile']['sts-enabled'] = true;
+    } else if (props.s3Variant === 's3-compat') {
+      warehouseObjectData['storage-credential']['credential-type'] = 'access-key';
+      warehouseObjectData['storage-profile'].flavor = 's3-compat';
     }
   }
 });

--- a/src/components/WarehouseStorageS3.vue
+++ b/src/components/WarehouseStorageS3.vue
@@ -16,7 +16,10 @@
       </v-card-title>
       <v-card-text>
         <v-alert
-          v-if="warehouseObjectData['storage-credential']['credential-type'] === 'access-key' && !props.s3Variant"
+          v-if="
+            warehouseObjectData['storage-credential']['credential-type'] === 'access-key' &&
+            !props.s3Variant
+          "
           type="info"
           variant="tonal"
           density="compact"
@@ -27,7 +30,8 @@
         </v-alert>
         <v-alert
           v-if="
-            warehouseObjectData['storage-credential']['credential-type'] === 'aws-system-identity' && !props.s3Variant
+            warehouseObjectData['storage-credential']['credential-type'] ===
+              'aws-system-identity' && !props.s3Variant
           "
           type="info"
           variant="tonal"
@@ -37,7 +41,10 @@
           Use IAM roles from the Lakekeeper server. Most secure for production AWS environments.
         </v-alert>
         <v-alert
-          v-if="warehouseObjectData['storage-credential']['credential-type'] === 'cloudflare-r2' && !props.s3Variant"
+          v-if="
+            warehouseObjectData['storage-credential']['credential-type'] === 'cloudflare-r2' &&
+            !props.s3Variant
+          "
           type="info"
           variant="tonal"
           density="compact"
@@ -46,7 +53,10 @@
           Optimized for Cloudflare's S3-compatible object storage.
         </v-alert>
 
-        <v-radio-group v-if="!props.s3Variant" v-model="warehouseObjectData['storage-credential']['credential-type']" row>
+        <v-radio-group
+          v-if="!props.s3Variant"
+          v-model="warehouseObjectData['storage-credential']['credential-type']"
+          row>
           <v-row>
             <v-col>
               <span class="text-subtitle-2 text-grey-darken-1">Select Credential Type:</span>
@@ -81,7 +91,10 @@
         </v-radio-group>
 
         <!-- AWS variant: show credential type toggle between access-key and system-identity -->
-        <v-radio-group v-if="props.s3Variant === 'aws'" v-model="warehouseObjectData['storage-credential']['credential-type']" row>
+        <v-radio-group
+          v-if="props.s3Variant === 'aws'"
+          v-model="warehouseObjectData['storage-credential']['credential-type']"
+          row>
           <v-row>
             <v-col>
               <span class="text-subtitle-2 text-grey-darken-1">Select Credential Type:</span>
@@ -250,12 +263,7 @@
             <v-combobox
               v-model="warehouseObjectData['storage-profile'].region"
               :items="regions"
-              :label="
-                getFieldLabel(
-                  'Bucket Region',
-                  isRegionRequired,
-                )
-              "
+              :label="getFieldLabel('Bucket Region', isRegionRequired)"
               placeholder="eu-central-1"
               :rules="[rules.requiredForAws]"
               :error="isRegionInvalid"
@@ -544,154 +552,153 @@
         </v-expansion-panels>
 
         <div v-if="props.s3Variant !== 'cloudflare-r2'">
-        <v-divider class="my-4"></v-divider>
+          <v-divider class="my-4"></v-divider>
 
-        <!-- Credential Vending Options -->
-        <h4 class="text-subtitle-1 mb-3 d-flex align-center">
-          Credential Vending Options
-          <v-tooltip location="top" max-width="400">
-            <template #activator="{ props: tooltipProps }">
-              <v-icon v-bind="tooltipProps" class="ml-2" size="small" color="info">
-                mdi-information-outline
-              </v-icon>
-            </template>
-            <span>
-              Enable clients to request temporary credentials directly from Lakekeeper instead of
-              using static credentials
-            </span>
-          </v-tooltip>
-        </h4>
-
-        <v-row>
-          <v-col>
-            <v-switch
-              v-model="warehouseObjectData['storage-profile']['remote-signing-enabled']"
-              color="primary"
-              :label="
-                warehouseObjectData['storage-profile']['remote-signing-enabled']
-                  ? `Remote Signing Enabled`
-                  : `Enable Remote Signing`
-              ">
-              <template #append>
-                <v-tooltip location="top" max-width="400">
-                  <template #activator="{ props: tooltipProps }">
-                    <v-icon v-bind="tooltipProps" size="small" color="info">
-                      mdi-help-circle-outline
-                    </v-icon>
-                  </template>
-                  <span>
-                    Allows Lakekeeper to sign S3 requests on behalf of clients. Clients send
-                    unsigned requests to Lakekeeper which adds authentication.
-                  </span>
-                </v-tooltip>
+          <!-- Credential Vending Options -->
+          <h4 class="text-subtitle-1 mb-3 d-flex align-center">
+            Credential Vending Options
+            <v-tooltip location="top" max-width="400">
+              <template #activator="{ props: tooltipProps }">
+                <v-icon v-bind="tooltipProps" class="ml-2" size="small" color="info">
+                  mdi-information-outline
+                </v-icon>
               </template>
-            </v-switch>
-          </v-col>
-        </v-row>
+              <span>
+                Enable clients to request temporary credentials directly from Lakekeeper instead of
+                using static credentials
+              </span>
+            </v-tooltip>
+          </h4>
 
-        <v-row>
-          <v-col>
-            <v-switch
-              v-model="warehouseObjectData['storage-profile']['sts-enabled']"
-              color="primary"
-              :label="
-                warehouseObjectData['storage-profile']['sts-enabled']
-                  ? `STS Enabled`
-                  : `Enable STS (Secure Token Service)`
-              ">
-              <template #append>
-                <v-tooltip location="top" max-width="400">
-                  <template #activator="{ props: tooltipProps }">
-                    <v-icon v-bind="tooltipProps" size="small" color="info">
-                      mdi-help-circle-outline
-                    </v-icon>
-                  </template>
-                  <span>
-                    Enables vending of temporary AWS credentials (STS tokens) to clients. Provides
-                    time-limited access to S3 without sharing long-term credentials.
-                  </span>
-                </v-tooltip>
-              </template>
-            </v-switch>
-          </v-col>
-        </v-row>
-
-        <v-row v-if="warehouseObjectData['storage-profile']['sts-enabled']">
-          <v-col>
-            <v-text-field
-              v-model="warehouseObjectData['storage-profile']['sts-role-arn']"
-              label="STS Role ARN"
-              placeholder="arn:aws:iam::123456789012:role/role-name"
-              hint="ARN of the IAM role to assume when vending STS credentials"></v-text-field>
-          </v-col>
-        </v-row>
-
-        <v-row v-if="warehouseObjectData['storage-profile']['sts-enabled']">
-          <v-col>
-            <v-text-field
-              v-model="warehouseObjectData['storage-profile']['sts-endpoint']"
-              label="STS Endpoint (Optional)"
-              placeholder="https://sts.amazonaws.com"
-              hint="Custom STS endpoint. If not set, the S3 endpoint is used for STS requests."
-              persistent-hint
-              clearable></v-text-field>
-          </v-col>
-        </v-row>
-
-        <!-- STS Session Tags -->
-        <div v-if="warehouseObjectData['storage-profile']['sts-enabled']">
           <v-row>
             <v-col>
-              <h4 class="text-subtitle-1 mb-2">STS Session Tags (Optional)</h4>
-              <p class="text-caption text-medium-emphasis mb-3">
-                Key-value pairs that are passed as session tags when assuming the STS role
-              </p>
+              <v-switch
+                v-model="warehouseObjectData['storage-profile']['remote-signing-enabled']"
+                color="primary"
+                :label="
+                  warehouseObjectData['storage-profile']['remote-signing-enabled']
+                    ? `Remote Signing Enabled`
+                    : `Enable Remote Signing`
+                ">
+                <template #append>
+                  <v-tooltip location="top" max-width="400">
+                    <template #activator="{ props: tooltipProps }">
+                      <v-icon v-bind="tooltipProps" size="small" color="info">
+                        mdi-help-circle-outline
+                      </v-icon>
+                    </template>
+                    <span>
+                      Allows Lakekeeper to sign S3 requests on behalf of clients. Clients send
+                      unsigned requests to Lakekeeper which adds authentication.
+                    </span>
+                  </v-tooltip>
+                </template>
+              </v-switch>
             </v-col>
           </v-row>
 
-          <div v-if="stsSessionTagsArray.length > 0">
-            <v-row v-for="(tag, index) in stsSessionTagsArray" :key="index">
-              <v-col cols="5">
-                <v-text-field
-                  v-model="tag.key"
-                  label="Key"
-                  placeholder="Environment"
-                  density="compact"
-                  @input="updateStsSessionTags"></v-text-field>
+          <v-row>
+            <v-col>
+              <v-switch
+                v-model="warehouseObjectData['storage-profile']['sts-enabled']"
+                color="primary"
+                :label="
+                  warehouseObjectData['storage-profile']['sts-enabled']
+                    ? `STS Enabled`
+                    : `Enable STS (Secure Token Service)`
+                ">
+                <template #append>
+                  <v-tooltip location="top" max-width="400">
+                    <template #activator="{ props: tooltipProps }">
+                      <v-icon v-bind="tooltipProps" size="small" color="info">
+                        mdi-help-circle-outline
+                      </v-icon>
+                    </template>
+                    <span>
+                      Enables vending of temporary AWS credentials (STS tokens) to clients. Provides
+                      time-limited access to S3 without sharing long-term credentials.
+                    </span>
+                  </v-tooltip>
+                </template>
+              </v-switch>
+            </v-col>
+          </v-row>
+
+          <v-row v-if="warehouseObjectData['storage-profile']['sts-enabled']">
+            <v-col>
+              <v-text-field
+                v-model="warehouseObjectData['storage-profile']['sts-role-arn']"
+                label="STS Role ARN"
+                placeholder="arn:aws:iam::123456789012:role/role-name"
+                hint="ARN of the IAM role to assume when vending STS credentials"></v-text-field>
+            </v-col>
+          </v-row>
+
+          <v-row v-if="warehouseObjectData['storage-profile']['sts-enabled']">
+            <v-col>
+              <v-text-field
+                v-model="warehouseObjectData['storage-profile']['sts-endpoint']"
+                label="STS Endpoint (Optional)"
+                placeholder="https://sts.amazonaws.com"
+                hint="Custom STS endpoint. If not set, the S3 endpoint is used for STS requests."
+                persistent-hint
+                clearable></v-text-field>
+            </v-col>
+          </v-row>
+
+          <!-- STS Session Tags -->
+          <div v-if="warehouseObjectData['storage-profile']['sts-enabled']">
+            <v-row>
+              <v-col>
+                <h4 class="text-subtitle-1 mb-2">STS Session Tags (Optional)</h4>
+                <p class="text-caption text-medium-emphasis mb-3">
+                  Key-value pairs that are passed as session tags when assuming the STS role
+                </p>
               </v-col>
-              <v-col cols="5">
-                <v-text-field
-                  v-model="tag.value"
-                  label="Value"
-                  placeholder="Production"
-                  density="compact"
-                  @input="updateStsSessionTags"></v-text-field>
-              </v-col>
-              <v-col cols="2" class="d-flex align-center">
+            </v-row>
+
+            <div v-if="stsSessionTagsArray.length > 0">
+              <v-row v-for="(tag, index) in stsSessionTagsArray" :key="index">
+                <v-col cols="5">
+                  <v-text-field
+                    v-model="tag.key"
+                    label="Key"
+                    placeholder="Environment"
+                    density="compact"
+                    @input="updateStsSessionTags"></v-text-field>
+                </v-col>
+                <v-col cols="5">
+                  <v-text-field
+                    v-model="tag.value"
+                    label="Value"
+                    placeholder="Production"
+                    density="compact"
+                    @input="updateStsSessionTags"></v-text-field>
+                </v-col>
+                <v-col cols="2" class="d-flex align-center">
+                  <v-btn
+                    icon="mdi-delete"
+                    variant="text"
+                    size="small"
+                    color="error"
+                    @click="removeStsSessionTag(index)"></v-btn>
+                </v-col>
+              </v-row>
+            </div>
+
+            <v-row>
+              <v-col>
                 <v-btn
-                  icon="mdi-delete"
-                  variant="text"
+                  prepend-icon="mdi-plus"
+                  variant="outlined"
                   size="small"
-                  color="error"
-                  @click="removeStsSessionTag(index)"></v-btn>
+                  class="mb-2"
+                  @click="addStsSessionTag">
+                  Session Tag
+                </v-btn>
               </v-col>
             </v-row>
           </div>
-
-          <v-row>
-            <v-col>
-              <v-btn
-                prepend-icon="mdi-plus"
-                variant="outlined"
-                size="small"
-                class="mb-2"
-                @click="addStsSessionTag">
-                Session Tag
-              </v-btn>
-            </v-col>
-          </v-row>
-        </div>
-
         </div>
 
         <v-btn-group
@@ -1021,8 +1028,7 @@ const rules = {
 // Computed properties for field requirements
 const isRegionRequired = computed(
   () =>
-    warehouseObjectData['storage-profile'].flavor === 'aws' ||
-    props.s3Variant === 'cloudflare-r2',
+    warehouseObjectData['storage-profile'].flavor === 'aws' || props.s3Variant === 'cloudflare-r2',
 );
 
 const areAccessKeysRequired = computed(() => {

--- a/src/gen/management/types.gen.ts
+++ b/src/gen/management/types.gen.ts
@@ -56,6 +56,11 @@ export type AzCredential = {
     'credential-type': 'azure-system-identity';
 };
 
+/**
+ * The type of Azure credential.
+ */
+export type AzCredentialType = 'client-credentials' | 'shared-access-key' | 'azure-system-identity';
+
 export type BootstrapRequest = {
     /**
      * Set to true if you accept LAKEKEEPER terms of use.
@@ -483,6 +488,11 @@ export type GcsCredential = {
     'credential-type': 'gcp-system-identity';
 };
 
+/**
+ * The type of GCS credential.
+ */
+export type GcsCredentialType = 'service-account-key' | 'gcp-system-identity';
+
 export type GcsProfile = {
     /**
      * Name of the GCS bucket
@@ -749,6 +759,7 @@ export type GetWarehouseResponse = {
      * Whether the warehouse is active.
      */
     status: WarehouseStatus;
+    'storage-credential-type'?: null | StorageCredentialType;
     /**
      * Storage profile used for the warehouse.
      */
@@ -1442,6 +1453,11 @@ export type S3Credential = (S3AccessKeyCredential & {
     'credential-type': 'cloudflare-r2';
 });
 
+/**
+ * The type of S3 credential.
+ */
+export type S3CredentialType = 'access-key' | 'aws-system-identity' | 'cloudflare-r2';
+
 export type S3Flavor = 'aws' | 's3-compat';
 
 export type S3Profile = {
@@ -1753,6 +1769,32 @@ export type StorageCredential = (S3Credential & {
 });
 
 /**
+ * The type of storage credential configured for a warehouse, without secret values.
+ *
+ * This is returned in API responses so clients know which credential type
+ * was selected (e.g. to restore radio button state in the UI).
+ */
+export type StorageCredentialType = {
+    /**
+     * S3 credential type
+     */
+    'credential-type': S3CredentialType;
+    type: 's3';
+} | {
+    /**
+     * Azure credential type
+     */
+    'credential-type': AzCredentialType;
+    type: 'az';
+} | {
+    /**
+     * GCS credential type
+     */
+    'credential-type': GcsCredentialType;
+    type: 'gcs';
+};
+
+/**
  * Controls how namespace and tabular paths are constructed under the warehouse base location.
  *
  * - `default` / omitted: one directory per direct-parent namespace, one per tabular, both with `"{uuid}"` segments.
@@ -2034,7 +2076,7 @@ export type UpdateWarehouseStorageRequest = {
      * Storage profile to use for the warehouse.
      * The new profile must point to the same location as the existing profile
      * to avoid data loss. For S3 this means that you may not change the
-     * bucket, key prefix, or region.
+     * bucket or key prefix. The region may only be changed if an endpoint is set.
      */
     'storage-profile': StorageProfile;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ export {
 export * from './composables/useAuth';
 
 // Export stores
-export { useVisualStore, type PolicyBuilderState } from './stores/visual';
+export { useVisualStore, type PolicyBuilderState, type OfflineReason } from './stores/visual';
 export { usePermissionStore } from './stores/permissions';
 export { useUserStore } from './stores/user';
 export { useNotificationStore } from './stores/notifications';

--- a/src/stores/visual.ts
+++ b/src/stores/visual.ts
@@ -171,6 +171,10 @@ export const useVisualStore = defineStore(
       offlineReason.value = reason;
     }
 
+    function clearOfflineReason() {
+      offlineReason.value = null;
+    }
+
     function getServerInfo() {
       return serverInfo;
     }
@@ -367,6 +371,7 @@ export const useVisualStore = defineStore(
       refreshNavTree,
       offlineReason,
       setOfflineReason,
+      clearOfflineReason,
       policyBuilderDraft,
       policyEditorText,
       projectList,

--- a/src/stores/visual.ts
+++ b/src/stores/visual.ts
@@ -19,6 +19,13 @@ export interface WarehouseSqlData {
   tabs: SqlTab[];
 }
 
+// Offline reason captured by router guard
+export interface OfflineReason {
+  statusCode: number;
+  message: string;
+  timestamp: number;
+}
+
 // Cedar Policy Builder draft state
 export interface PolicyBuilderState {
   effect: 'permit' | 'forbid';
@@ -61,6 +68,9 @@ export const useVisualStore = defineStore(
 
     // Requested tab for namespace detail page (set by navigation tree context menu)
     const requestedNamespaceTab = ref<string | null>(null);
+
+    // Offline reason captured by router guard when server is unreachable
+    const offlineReason = ref<OfflineReason | null>(null);
 
     // Cedar Policy Builder & Editor state
     const policyBuilderDraft = ref<PolicyBuilderState>({
@@ -155,6 +165,10 @@ export const useVisualStore = defineStore(
     function setServerInfo(serverInfoInput: ServerInfo) {
       // Use the authz-backend from the server directly
       Object.assign(serverInfo, serverInfoInput);
+    }
+
+    function setOfflineReason(reason: OfflineReason) {
+      offlineReason.value = reason;
     }
 
     function getServerInfo() {
@@ -351,6 +365,8 @@ export const useVisualStore = defineStore(
       warehouseTreeState,
       navTreeRefreshSignal,
       refreshNavTree,
+      offlineReason,
+      setOfflineReason,
       policyBuilderDraft,
       policyEditorText,
       projectList,


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat(ui): show connection diagnostics on server-offline page
feat(ui): add memory card game to server-offline page
END_COMMIT_OVERRIDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare R2 and S3-compatible storage variants with variant-specific credential UIs.
  * API responses now include a best-effort, secret-free storage credential type indicator for warehouses.

* **Bug Fixes**
  * Fixed GCS credential-type initialization to reflect configured values.

* **Improvements**
  * Improved warehouse credential selection, submission, and error handling flows.
  * Updated storage icons and relaxed storage-profile region constraints when an endpoint is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->