### PR TITLE
chore: remove unused @hey-api/client-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@hey-api/client-fetch": "^0.13.1",
     "@hey-api/openapi-ts": "^0.87.0",
     "@types/chart.js": "^4.0.1",
     "@types/d3": "^7.4.3",


### PR DESCRIPTION
## Summary
- Remove `@hey-api/client-fetch` from `devDependencies` — it is not imported anywhere in source or generated code
- The `@hey-api/openapi-ts` generator embeds an inline HTTP client in `src/gen/*/client/`, so the separate package is not needed at runtime or build time

## Test plan
- [ ] `just build` passes
- [ ] No import errors in generated SDK files

BEGIN_COMMIT_OVERRIDE
chore(ui): remove unused @hey-api/client-fetch dependency
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->