### PR TITLE
chore: migrate Vite minifier from esbuild to oxc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
-        "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.87.0",
         "@types/chart.js": "^4.0.1",
         "@types/d3": "^7.4.3",
@@ -500,20 +499,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@hey-api/client-fetch": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@hey-api/client-fetch/-/client-fetch-0.13.1.tgz",
-      "integrity": "sha512-29jBRYNdxVGlx5oewFgOrkulZckpIpBIRHth3uHFn1PrL2ucMy52FvWOY3U3dVx2go1Z3kUmMi6lr07iOpUqqA==",
-      "deprecated": "Starting with v0.73.0, this package is bundled directly inside @hey-api/openapi-ts.",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/hey-api"
-      },
-      "peerDependencies": {
-        "@hey-api/openapi-ts": "< 2"
       }
     },
     "node_modules/@hey-api/codegen-core": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@hey-api/client-fetch": "^0.13.1",
     "@hey-api/openapi-ts": "^0.87.0",
     "@types/chart.js": "^4.0.1",
     "@types/d3": "^7.4.3",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,12 +124,8 @@ export default defineConfig({
       },
     },
     cssCodeSplit: false,
-    minify: 'esbuild',
+    minify: 'oxc',
     target: 'esnext',
-  },
-  esbuild: {
-    keepNames: false,
-    minifyIdentifiers: true,
   },
   optimizeDeps: {
     exclude: ['@duckdb/duckdb-wasm'],


### PR DESCRIPTION
## Summary
- Switch `minify: 'esbuild'` → `minify: 'oxc'` and remove the `esbuild` config block
- Vite v8 no longer bundles esbuild; using `minify: 'esbuild'` now fails with `Cannot find package 'esbuild'`
- Oxc is Vite v8's built-in default minifier

BEGIN_COMMIT_OVERRIDE
chore(ui): migrate Vite minifier from esbuild to oxc
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)