### PR TITLE
chore: ignore major upgrades for typescript, vuetify, and eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vuetify"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "*eslint*"
+        update-types: ["version-update:semver-major"]
     groups:
       eslint:
         patterns:

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,11 @@
     {
       "matchUpdateTypes": ["patch"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["typescript", "vuetify", "/eslint/"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Ignore TypeScript, Vuetify, and ESLint **major** version bumps in both `renovate.json` and `dependabot.yml`
- Deferring TypeScript 6/7, Vuetify 4, and ESLint major until explicitly planned as a coordinated upgrade

BEGIN_COMMIT_OVERRIDE
chore(ui): ignore major upgrades for typescript, vuetify, and eslint
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)