### PR TITLE
chore: remove deprecated @types/chart.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@hey-api/openapi-ts": "^0.87.0",
-    "@types/chart.js": "^4.0.1",
     "@types/d3": "^7.4.3",
     "@types/json-bigint": "^1.0.4",
     "@vitejs/plugin-vue": "^6.0.6",


### PR DESCRIPTION
## Summary
- Remove `@types/chart.js` from `devDependencies`
- Chart.js v4 ships its own TypeScript declarations (`dist/types.d.ts`) — the `@types/chart.js` package targets v2 and is deprecated
- Fixes the Renovate Dependency Dashboard deprecation warning in issue #116

BEGIN_COMMIT_OVERRIDE
chore(ui): remove deprecated @types/chart.js
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)