### PR TITLE
chore: block all major dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "*eslint*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       eslint:
         patterns:

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,6 @@
       "automerge": true
     },
     {
-      "matchPackageNames": ["typescript", "vuetify", "/eslint/"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     }


### PR DESCRIPTION
Block all major version bumps in Renovate (blanket rule) and Dependabot, replacing the previous per-package ignore list. Majors are still visible in the Renovate Dependency Dashboard under "Ignored or Blocked" — no PRs are opened automatically.

Also adds `@types/node` major ignore to Dependabot (tracks Node.js version; bumping to @types/node@25 on a Node 24 LTS runtime exposes non-existent APIs).

BEGIN_COMMIT_OVERRIDE
chore(ui): block all major dependency updates in Renovate and Dependabot
END_COMMIT_OVERRIDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to refine major version update handling for specific packages, improving consistency across dependency management rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->