### PR TITLE
fix: enlarge LoQE DDL dialog and respect custom extension repo

### DIFF
--- a/src/components/LoQEExplorer.vue
+++ b/src/components/LoQEExplorer.vue
@@ -758,8 +758,8 @@
     </v-dialog>
 
     <!-- DDL Dialog -->
-    <v-dialog v-model="showDDLDialog" max-width="800" scrollable>
-      <v-card>
+    <v-dialog v-model="showDDLDialog" max-width="1200" height="80vh" scrollable>
+      <v-card style="height: 100%; display: flex; flex-direction: column">
         <v-card-title class="d-flex align-center text-subtitle-1">
           <v-icon size="small" class="mr-2">mdi-code-tags</v-icon>
           {{ ddlTitle }}
@@ -769,7 +769,7 @@
           </v-btn>
         </v-card-title>
         <v-divider />
-        <v-card-text class="pa-0" style="max-height: 500px; overflow: auto">
+        <v-card-text class="pa-0" style="flex: 1; overflow: auto">
           <div v-if="isDDLLoading" class="text-center py-8">
             <v-progress-circular indeterminate size="32" color="primary" />
             <div class="text-caption mt-2 text-grey">Loading metadata…</div>
@@ -777,7 +777,7 @@
           <div v-else-if="ddlError" class="pa-4">
             <v-alert type="error" variant="tonal" density="compact">{{ ddlError }}</v-alert>
           </div>
-          <SqlEditor v-else :model-value="ddlContent" disabled min-height="200px" placeholder="" />
+          <SqlEditor v-else :model-value="ddlContent" disabled min-height="60vh" placeholder="" />
         </v-card-text>
         <v-divider />
         <v-card-actions class="px-4 py-2">

--- a/src/composables/loqe/LoQEEngine.ts
+++ b/src/composables/loqe/LoQEEngine.ts
@@ -383,12 +383,10 @@ export class LoQEEngine {
       const pooled = await this.pool.acquire();
       try {
         await pooled.connection.query('SET builtin_httpfs = false');
-        await pooled.connection.query('INSTALL httpfs');
-        await pooled.connection.query('LOAD httpfs');
-        this.installedExtensions.add('httpfs');
       } finally {
         this.pool.release(pooled);
       }
+      await this.installExtension('httpfs');
     }
 
     if (!this.installedExtensions.has('iceberg')) {

--- a/src/composables/loqe/LoQEEngine.ts
+++ b/src/composables/loqe/LoQEEngine.ts
@@ -326,6 +326,11 @@ export class LoQEEngine {
         await pooled.connection.query(`RESET custom_extension_repository`);
       }
 
+      // httpfs must not use the built-in implementation so the custom repo is used
+      if (name === 'httpfs') {
+        await pooled.connection.query('SET builtin_httpfs = false');
+      }
+
       await pooled.connection.query(`INSTALL ${name}`);
       await pooled.connection.query(`LOAD ${name}`);
       this.installedExtensions.add(name);
@@ -380,12 +385,6 @@ export class LoQEEngine {
 
     // Ensure required extensions are loaded
     if (!this.installedExtensions.has('httpfs')) {
-      const pooled = await this.pool.acquire();
-      try {
-        await pooled.connection.query('SET builtin_httpfs = false');
-      } finally {
-        this.pool.release(pooled);
-      }
       await this.installExtension('httpfs');
     }
 


### PR DESCRIPTION
## Summary
- DDL dialog enlarged to `max-width: 1200` / `height: 80vh`; `SqlEditor` fills the dialog height instead of being capped at `500px`
- `attachCatalog` now installs `httpfs` via `installExtension()` so the **Custom extension repository URL** setting is respected — fixes offline/air-gapped environments (lakekeeper/lakekeeper#1619)

BEGIN_COMMIT_OVERRIDE
fix(ui): enlarge DDL dialog and respect custom extension repo for httpfs
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Expanded the DDL display dialog with a larger viewing area and reorganized layout structure, providing improved readability when viewing database schema definitions.

* **Refactor**
  * Optimized the extension loading mechanism with improved resource management to enhance system stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->