### PR TITLE
fix: correct types entry path for TypeScript 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "main": "dist/console-components.umd.js",
   "module": "dist/console-components.es.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/console-components.es.js",
       "require": "./dist/console-components.umd.js"
     },


### PR DESCRIPTION
TypeScript 6 changed how `rootDir` is inferred. With TS6, `vite-plugin-dts` outputs to `dist/types/src/index.d.ts` instead of `dist/types/index.d.ts`. The `package.json` `types` and `exports.types` fields were still pointing at the old path, causing consuming apps to fail with TS7016: "Could not find a declaration file".

BEGIN_COMMIT_OVERRIDE
fix(ui): correct types entry path for TypeScript 6
END_COMMIT_OVERRIDE