### PR TITLE
fix: add view select action and rename S3 credential key fields

### DIFF
--- a/openapi/management-open-api.yaml
+++ b/openapi/management-open-api.yaml
@@ -5399,6 +5399,14 @@ components:
             action:
               type: string
               enum:
+                - select
+        - type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum:
                 - commit
             removed_properties:
               type: array
@@ -6054,6 +6062,7 @@ components:
         - grant_pass_grants
         - grant_manage_grants
         - grant_describe
+        - grant_select
         - grant_modify
         - change_ownership
     OpenFGAWarehouseAction:
@@ -6417,17 +6426,17 @@ components:
       type: object
       title: S3CredentialAccessKey
       required:
-        - aws-access-key-id
-        - aws-secret-access-key
+        - access-key-id
+        - secret-access-key
       properties:
-        aws-access-key-id:
-          type: string
-        aws-secret-access-key:
+        access-key-id:
           type: string
         external-id:
           type:
             - string
             - 'null'
+        secret-access-key:
+          type: string
     S3AwsSystemIdentityCredential:
       type: object
       title: S3CredentialSystemIdentity
@@ -7784,11 +7793,13 @@ components:
         - drop
         - commit
         - get_metadata
+        - select
         - rename
         - read_assignments
         - grant_pass_grants
         - grant_manage_grants
         - grant_describe
+        - grant_select
         - grant_modify
         - change_ownership
         - get_tasks
@@ -7849,6 +7860,17 @@ components:
                 type:
                   type: string
                   enum:
+                    - select
+          title: ViewAssignmentSelect
+        - allOf:
+            - $ref: '#/components/schemas/UserOrRole'
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
                     - modify
           title: ViewAssignmentModify
     ViewRelation:
@@ -7858,6 +7880,7 @@ components:
         - pass_grants
         - manage_grants
         - describe
+        - select
         - modify
     WarehouseAction:
       type: string

--- a/src/common/permissionActions.ts
+++ b/src/common/permissionActions.ts
@@ -95,6 +95,7 @@ const catalogTableActions: LakekeeperTableAction[] = [
 const catalogViewActions: LakekeeperViewAction[] = [
   { action: 'drop' },
   { action: 'get_metadata' },
+  { action: 'select' },
   { action: 'commit' },
   { action: 'include_in_list' },
   { action: 'rename' },

--- a/src/components/PermissionAssignDialog.vue
+++ b/src/components/PermissionAssignDialog.vue
@@ -278,6 +278,7 @@ const viewRelation: ViewRelation[] = [
   'pass_grants',
   'manage_grants',
   'describe',
+  'select',
   'modify',
 ];
 const warehouseRelation: WarehouseRelation[] = [

--- a/src/components/WarehouseAddDialog.vue
+++ b/src/components/WarehouseAddDialog.vue
@@ -362,8 +362,8 @@ const warehouseObjectS3 = reactive<WarehousObject>({
   },
   'storage-credential': {
     type: 's3',
-    'aws-access-key-id': '',
-    'aws-secret-access-key': '',
+    'access-key-id': '',
+    'secret-access-key': '',
     'credential-type': 'access-key',
   },
 });
@@ -398,8 +398,8 @@ const warehouseObjectS3Compat = reactive<WarehousObject>({
   },
   'storage-credential': {
     type: 's3',
-    'aws-access-key-id': '',
-    'aws-secret-access-key': '',
+    'access-key-id': '',
+    'secret-access-key': '',
     'credential-type': 'access-key',
   },
 });
@@ -536,8 +536,8 @@ function cleanS3Credential(cred: any): StorageCredential {
   return {
     type: 's3',
     'credential-type': 'access-key',
-    'aws-access-key-id': cred['aws-access-key-id'] ?? '',
-    'aws-secret-access-key': cred['aws-secret-access-key'] ?? '',
+    'access-key-id': cred['access-key-id'] ?? '',
+    'secret-access-key': cred['secret-access-key'] ?? '',
     'external-id': cred['external-id'] || null,
   } as StorageCredential;
 }

--- a/src/components/WarehouseStorageS3.vue
+++ b/src/components/WarehouseStorageS3.vue
@@ -123,7 +123,7 @@
         <!-- Access Key Fields -->
         <v-text-field
           v-if="warehouseObjectData['storage-credential']['credential-type'] === 'access-key'"
-          v-model="warehouseObjectData['storage-credential']['aws-access-key-id']"
+          v-model="warehouseObjectData['storage-credential']['access-key-id']"
           autocomplete="username"
           :label="getFieldLabel('AWS Access Key ID', areAccessKeysRequired)"
           placeholder="AKIAIOSFODNN7EXAMPLE"
@@ -133,11 +133,11 @@
           :style="isAccessKeyIdInvalid ? 'color: rgb(var(--v-theme-error));' : ''"></v-text-field>
         <v-text-field
           v-if="warehouseObjectData['storage-credential']['credential-type'] === 'access-key'"
-          v-model="warehouseObjectData['storage-credential']['aws-secret-access-key']"
+          v-model="warehouseObjectData['storage-credential']['secret-access-key']"
           :append-inner-icon="showPassword ? 'mdi-eye-outline' : 'mdi-eye-off-outline'"
           autocomplete="current-password"
           :label="getFieldLabel('AWS Secret Access Key', areAccessKeysRequired)"
-          placeholder="your-aws-secret-access-key"
+          placeholder="your-secret-access-key"
           :rules="[rules.requiredForAccessKey]"
           :type="showPassword ? 'text' : 'password'"
           :error="isSecretKeyInvalid"
@@ -199,8 +199,8 @@
           color="success"
           :disabled="
             warehouseObjectData['storage-credential']['credential-type'] === 'access-key' &&
-            (!warehouseObjectData['storage-credential']['aws-access-key-id'] ||
-              !warehouseObjectData['storage-credential']['aws-secret-access-key'])
+            (!warehouseObjectData['storage-credential']['access-key-id'] ||
+              !warehouseObjectData['storage-credential']['secret-access-key'])
           "
           @click="emitNewCredentials">
           Update Credentials
@@ -709,8 +709,8 @@
             type="submit"
             :disabled="
               (warehouseObjectData['storage-credential']['credential-type'] === 'access-key' &&
-                (!warehouseObjectData['storage-credential']['aws-access-key-id'] ||
-                  !warehouseObjectData['storage-credential']['aws-secret-access-key'])) ||
+                (!warehouseObjectData['storage-credential']['access-key-id'] ||
+                  !warehouseObjectData['storage-credential']['secret-access-key'])) ||
               !warehouseObjectData['storage-profile'].bucket ||
               (warehouseObjectData['storage-profile'].flavor === 'aws' &&
                 !warehouseObjectData['storage-profile'].region) ||
@@ -734,8 +734,8 @@
                 size="small"
                 :disabled="
                   (warehouseObjectData['storage-credential']['credential-type'] === 'access-key' &&
-                    (!warehouseObjectData['storage-credential']['aws-access-key-id'] ||
-                      !warehouseObjectData['storage-credential']['aws-secret-access-key'])) ||
+                    (!warehouseObjectData['storage-credential']['access-key-id'] ||
+                      !warehouseObjectData['storage-credential']['secret-access-key'])) ||
                   !warehouseObjectData['storage-profile'].bucket ||
                   (warehouseObjectData['storage-profile'].flavor === 'aws' &&
                     !warehouseObjectData['storage-profile'].region) ||
@@ -770,8 +770,8 @@
           color="success"
           :disabled="
             (warehouseObjectData['storage-credential']['credential-type'] === 'access-key' &&
-              (!warehouseObjectData['storage-credential']['aws-access-key-id'] ||
-                !warehouseObjectData['storage-credential']['aws-secret-access-key'])) ||
+              (!warehouseObjectData['storage-credential']['access-key-id'] ||
+                !warehouseObjectData['storage-credential']['secret-access-key'])) ||
             !warehouseObjectData['storage-profile'].bucket ||
             (warehouseObjectData['storage-profile'].flavor === 'aws' &&
               !warehouseObjectData['storage-profile'].region) ||
@@ -854,8 +854,8 @@ const warehouseObjectData = reactive<{
   'storage-credential': {
     type: 's3',
     'credential-type': 'access-key',
-    'aws-access-key-id': '',
-    'aws-secret-access-key': '',
+    'access-key-id': '',
+    'secret-access-key': '',
     'external-id': null, // Optional, can be used for both credential types
   },
 });
@@ -1040,7 +1040,7 @@ const isAccessKeyIdInvalid = computed(() => {
   return (
     areAccessKeysRequired.value &&
     warehouseObjectData['storage-credential']['credential-type'] === 'access-key' &&
-    !(warehouseObjectData['storage-credential'] as any)['aws-access-key-id']
+    !(warehouseObjectData['storage-credential'] as any)['access-key-id']
   );
 });
 
@@ -1048,7 +1048,7 @@ const isSecretKeyInvalid = computed(() => {
   return (
     areAccessKeysRequired.value &&
     warehouseObjectData['storage-credential']['credential-type'] === 'access-key' &&
-    !(warehouseObjectData['storage-credential'] as any)['aws-secret-access-key']
+    !(warehouseObjectData['storage-credential'] as any)['secret-access-key']
   );
 });
 
@@ -1123,8 +1123,8 @@ const buildCleanCredential = (): S3Credential & { type: 's3' } => {
   return {
     type: 's3' as const,
     'credential-type': 'access-key',
-    'aws-access-key-id': warehouseObjectData['storage-credential']['aws-access-key-id'],
-    'aws-secret-access-key': warehouseObjectData['storage-credential']['aws-secret-access-key'],
+    'access-key-id': warehouseObjectData['storage-credential']['access-key-id'],
+    'secret-access-key': warehouseObjectData['storage-credential']['secret-access-key'],
     'external-id': warehouseObjectData['storage-credential']['external-id'] || null,
   } as S3Credential & { type: 's3' };
 };

--- a/src/gen/management/types.gen.ts
+++ b/src/gen/management/types.gen.ts
@@ -945,6 +945,8 @@ export type LakekeeperViewAction = {
 } | {
     action: 'get_metadata';
 } | {
+    action: 'select';
+} | {
     action: 'commit';
     removed_properties?: Array<string>;
     updated_properties?: {
@@ -1213,7 +1215,7 @@ export type OpenFgaServerAction = 'read_assignments' | 'grant_admin';
 
 export type OpenFgaTableAction = 'read_assignments' | 'grant_pass_grants' | 'grant_manage_grants' | 'grant_describe' | 'grant_select' | 'grant_modify' | 'change_ownership';
 
-export type OpenFgaViewAction = 'read_assignments' | 'grant_pass_grants' | 'grant_manage_grants' | 'grant_describe' | 'grant_modify' | 'change_ownership';
+export type OpenFgaViewAction = 'read_assignments' | 'grant_pass_grants' | 'grant_manage_grants' | 'grant_describe' | 'grant_select' | 'grant_modify' | 'change_ownership';
 
 export type OpenFgaWarehouseAction = 'read_assignments' | 'grant_create' | 'grant_describe' | 'grant_modify' | 'grant_select' | 'grant_pass_grants' | 'grant_manage_grants' | 'change_ownership';
 
@@ -1410,9 +1412,9 @@ export type RoleRelation = 'assignee' | 'ownership';
  * S3CredentialAccessKey
  */
 export type S3AccessKeyCredential = {
-    'aws-access-key-id': string;
-    'aws-secret-access-key': string;
+    'access-key-id': string;
     'external-id'?: string | null;
+    'secret-access-key': string;
 };
 
 /**
@@ -2140,7 +2142,7 @@ export type UserOrRole = {
  */
 export type UserType = 'human' | 'application';
 
-export type ViewAction = 'drop' | 'commit' | 'get_metadata' | 'rename' | 'read_assignments' | 'grant_pass_grants' | 'grant_manage_grants' | 'grant_describe' | 'grant_modify' | 'change_ownership' | 'get_tasks' | 'control_tasks' | 'set_protection';
+export type ViewAction = 'drop' | 'commit' | 'get_metadata' | 'select' | 'rename' | 'read_assignments' | 'grant_pass_grants' | 'grant_manage_grants' | 'grant_describe' | 'grant_select' | 'grant_modify' | 'change_ownership' | 'get_tasks' | 'control_tasks' | 'set_protection';
 
 export type ViewAssignment = (UserOrRole & {
     type: 'ownership';
@@ -2151,10 +2153,12 @@ export type ViewAssignment = (UserOrRole & {
 }) | (UserOrRole & {
     type: 'describe';
 }) | (UserOrRole & {
+    type: 'select';
+}) | (UserOrRole & {
     type: 'modify';
 });
 
-export type ViewRelation = 'ownership' | 'pass_grants' | 'manage_grants' | 'describe' | 'modify';
+export type ViewRelation = 'ownership' | 'pass_grants' | 'manage_grants' | 'describe' | 'select' | 'modify';
 
 export type WarehouseAction = 'create_namespace' | 'delete' | 'modify_storage' | 'modify_storage_credential' | 'get_config' | 'get_metadata' | 'list_namespaces' | 'include_in_list' | 'deactivate' | 'activate' | 'rename' | 'list_deleted_tabulars' | 'read_assignments' | 'grant_create' | 'grant_describe' | 'grant_modify' | 'grant_select' | 'grant_pass_grants' | 'grant_manage_grants' | 'change_ownership' | 'get_all_tasks' | 'control_all_tasks' | 'set_protection' | 'get_endpoint_statistics';
 


### PR DESCRIPTION
- Add `select` to `catalogViewActions` in `permissionActions.ts` and to the `viewRelation` options in `PermissionAssignDialog.vue`
- Rename S3 credential fields `aws-access-key-id` → `access-key-id` and `aws-secret-access-key` → `secret-access-key` in `WarehouseStorageS3.vue` and `WarehouseAddDialog.vue` to match the updated OpenAPI spec / regenerated types

BEGIN_COMMIT_OVERRIDE
fix(ui): add view select action and rename S3 credential key fields
END_COMMIT_OVERRIDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "select" permission for view-level operations, enabling more granular access control.

* **Updates**
  * S3 storage credential field names have been standardized. Update existing configurations: `aws-access-key-id` → `access-key-id` and `aws-secret-access-key` → `secret-access-key`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->