### PR TITLE
fix: refresh nav tree on warehouse rename/add, import button, fix stale preview name

### DIFF
--- a/src/components/TablePreview.vue
+++ b/src/components/TablePreview.vue
@@ -47,7 +47,7 @@
     <!-- Results -->
     <div v-else-if="queryResults">
       <div class="text-h6 mb-3">
-        Preview: {{ warehouseName }}.{{ namespaceDisplay }}.{{ tableName }}
+        Preview: {{ resolvedWarehouseName }}.{{ namespaceDisplay }}.{{ tableName }}
       </div>
 
       <!-- Branch & Time Travel Toolbar -->
@@ -158,6 +158,7 @@ const props = defineProps<{
   tableName: string;
   catalogUrl: string;
   storageType?: string;
+  warehouseName?: string;
 }>();
 
 const config = inject<any>('appConfig', { enabledAuthentication: false });
@@ -181,7 +182,7 @@ const storageValidation = useStorageValidation(
 const isLoading = ref(true);
 const error = ref<string | null>(null);
 const queryResults = ref<any>(null);
-const warehouseName = ref<string | undefined>(undefined);
+const resolvedWarehouseName = ref<string | undefined>(undefined);
 const loadedTable = ref<BigIntLoadTableResult | null>(null);
 const selectedSnapshot = ref<string | null>(null);
 const selectedBranch = ref<string>('main');
@@ -307,7 +308,7 @@ async function loadPreview() {
   try {
     // Load warehouse
     const wh = await functions.getWarehouse(props.warehouseId);
-    warehouseName.value = wh.name;
+    resolvedWarehouseName.value = wh.name;
 
     // Load table metadata via loadTableCustomized (uses json-bigint to preserve snapshot IDs)
     if (!loadedTable.value) {
@@ -328,17 +329,17 @@ async function loadPreview() {
 
     // Check if catalog is already attached
     const attached = loqe.attachedCatalogs.value;
-    const alreadyAttached = attached.some((c) => c.catalogName === warehouseName.value);
+    const alreadyAttached = attached.some((c) => c.catalogName === resolvedWarehouseName.value);
     if (!alreadyAttached) {
       await loqe.attachCatalog({
-        catalogName: warehouseName.value,
+        catalogName: resolvedWarehouseName.value,
         restUri: props.catalogUrl,
         accessToken: userStore.user.access_token,
         projectId: wh['project-id'],
       });
     }
 
-    const tablePath = `"${warehouseName.value}"."${namespaceDisplay.value}"."${props.tableName}"`;
+    const tablePath = `"${resolvedWarehouseName.value}"."${namespaceDisplay.value}"."${props.tableName}"`;
 
     // Build query with optional time travel
     let sql: string;
@@ -388,6 +389,14 @@ function downloadCSV() {
 onMounted(() => {
   loadPreview();
 });
+
+// Keep local resolvedWarehouseName in sync with prop (updated after rename in parent)
+watch(
+  () => props.warehouseName,
+  (name) => {
+    if (name) resolvedWarehouseName.value = name;
+  },
+);
 
 // Watch for table/namespace/warehouse changes and reload preview
 watch([() => props.tableName, () => props.namespaceId, () => props.warehouseId], () => {

--- a/src/components/TablePreview.vue
+++ b/src/components/TablePreview.vue
@@ -306,9 +306,14 @@ async function loadPreview() {
     return;
   }
   try {
-    // Load warehouse
+    // Load warehouse — snapshot name immediately so later async steps use a stable value
     const wh = await functions.getWarehouse(props.warehouseId);
-    resolvedWarehouseName.value = wh.name;
+    const warehouseName = wh.name;
+    if (!warehouseName) {
+      error.value = 'Warehouse name is unavailable.';
+      return;
+    }
+    resolvedWarehouseName.value = warehouseName;
 
     // Load table metadata via loadTableCustomized (uses json-bigint to preserve snapshot IDs)
     if (!loadedTable.value) {
@@ -329,17 +334,17 @@ async function loadPreview() {
 
     // Check if catalog is already attached
     const attached = loqe.attachedCatalogs.value;
-    const alreadyAttached = attached.some((c) => c.catalogName === resolvedWarehouseName.value);
+    const alreadyAttached = attached.some((c) => c.catalogName === warehouseName);
     if (!alreadyAttached) {
       await loqe.attachCatalog({
-        catalogName: resolvedWarehouseName.value,
+        catalogName: warehouseName,
         restUri: props.catalogUrl,
         accessToken: userStore.user.access_token,
         projectId: wh['project-id'],
       });
     }
 
-    const tablePath = `"${resolvedWarehouseName.value}"."${namespaceDisplay.value}"."${props.tableName}"`;
+    const tablePath = `"${warehouseName}"."${namespaceDisplay.value}"."${props.tableName}"`;
 
     // Build query with optional time travel
     let sql: string;

--- a/src/components/WarehouseAddDialog.vue
+++ b/src/components/WarehouseAddDialog.vue
@@ -36,19 +36,23 @@
     </template>
     <v-card style="max-height: 90vh; overflow-y: auto; min-width: 850px; width: 100%">
       <v-card-title v-if="props.objectType === ObjectType.WAREHOUSE" class="mt-8">
-        <v-row>
+        <v-row align="center">
           <v-col cols="8" class="ml-2">Add new warehouse</v-col>
-          <v-col>
-            <v-switch v-model="useFileInput">
-              <template #label>
-                <v-icon class="mr-2" color="info">
-                  {{ useFileInput ? 'mdi-keyboard-outline' : 'mdi-code-json' }}
-                </v-icon>
-                <span>
-                  {{ useFileInput ? 'Activate manual input' : 'Activate JSON upload' }}
-                </span>
-              </template>
-            </v-switch>
+          <v-col class="d-flex justify-end">
+            <input
+              ref="fileInputRef"
+              type="file"
+              accept="application/json"
+              style="display: none"
+              @change="handleFileImport" />
+            <v-btn
+              color="info"
+              prepend-icon="mdi-upload"
+              size="small"
+              variant="outlined"
+              @click="fileInputRef?.click()">
+              Import Warehouse
+            </v-btn>
           </v-col>
         </v-row>
       </v-card-title>
@@ -110,7 +114,7 @@
               </span>
             </v-col>
           </v-row>
-          <v-form v-if="!useFileInput">
+          <v-form>
             <v-text-field
               v-if="emptyWarehouse"
               v-model="warehouseName"
@@ -198,6 +202,7 @@
               <v-tabs-window v-model="storageCredentialType" class="mt-4" style="min-height: 600px">
                 <v-tabs-window-item value="S3">
                   <WarehouseStorageS3
+                    :key="importKey"
                     :credentials-only="emptyWarehouse"
                     :intent="intent"
                     :object-type="objectType"
@@ -210,6 +215,7 @@
 
                 <v-tabs-window-item value="GCS">
                   <WarehouseStorageGCS
+                    :key="importKey"
                     :credentials-only="emptyWarehouse"
                     :intent="intent"
                     :object-type="objectType"
@@ -221,6 +227,7 @@
 
                 <v-tabs-window-item value="AZURE">
                   <WarehouseStorageAzure
+                    :key="importKey"
                     :credentials-only="emptyWarehouse"
                     :intent="intent"
                     :object-type="objectType"
@@ -232,6 +239,7 @@
 
                 <v-tabs-window-item value="R2">
                   <WarehouseStorageS3
+                    :key="importKey"
                     :credentials-only="emptyWarehouse"
                     :intent="intent"
                     :object-type="objectType"
@@ -244,6 +252,7 @@
 
                 <v-tabs-window-item value="S3_COMPAT">
                   <WarehouseStorageS3
+                    :key="importKey"
                     :credentials-only="emptyWarehouse"
                     :intent="intent"
                     :object-type="objectType"
@@ -256,11 +265,6 @@
               </v-tabs-window>
             </span>
           </v-form>
-
-          <WarehouseStorageJSON
-            v-if="useFileInput"
-            @submit="createWarehouseJSON"
-            @preload="preloadWarehouseJSON"></WarehouseStorageJSON>
         </v-card-text>
         <v-card-actions>
           <v-btn
@@ -284,7 +288,6 @@ import { useVisualStore } from '../stores/visual';
 import WarehouseStorageS3 from './WarehouseStorageS3.vue';
 import WarehouseStorageAzure from './WarehouseStorageAzure.vue';
 import WarehouseStorageGCS from './WarehouseStorageGCS.vue';
-import WarehouseStorageJSON from './WarehouseStorageJSON.vue';
 import cfIcon from '@/assets/cf.svg';
 
 import {
@@ -331,10 +334,27 @@ const props = defineProps<{
   processStatus: string;
 }>();
 
+const importKey = ref(0);
+
 const min = ref(0);
 const max = ref(90);
 const slider = ref(7);
-const useFileInput = ref(false);
+const fileInputRef = ref<HTMLInputElement | null>(null);
+
+function handleFileImport(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    try {
+      preloadWarehouseJSON(JSON.parse(e.target?.result as string));
+    } catch (err) {
+      console.error('Error parsing JSON:', err);
+    }
+  };
+  reader.readAsText(file);
+  (event.target as HTMLInputElement).value = '';
+}
 
 // const storageCredentialTypes = ref(['S3', 'GCS', 'AZURE']);
 const storageCredentialType = ref('');
@@ -513,55 +533,6 @@ async function createWarehouse(
   }
 }
 
-function cleanS3Credential(cred: any): StorageCredential {
-  if (cred?.type !== 's3') return cred;
-  const credType = cred['credential-type'];
-  if (credType === 'cloudflare-r2') {
-    return {
-      type: 's3',
-      'credential-type': 'cloudflare-r2',
-      'access-key-id': cred['access-key-id'] ?? '',
-      'secret-access-key': cred['secret-access-key'] ?? '',
-      token: cred.token ?? '',
-      'account-id': cred['account-id'] ?? '',
-    } as StorageCredential;
-  }
-  if (credType === 'aws-system-identity') {
-    return {
-      type: 's3',
-      'credential-type': 'aws-system-identity',
-      'external-id': cred['external-id'] || null,
-    } as StorageCredential;
-  }
-  return {
-    type: 's3',
-    'credential-type': 'access-key',
-    'access-key-id': cred['access-key-id'] ?? '',
-    'secret-access-key': cred['secret-access-key'] ?? '',
-    'external-id': cred['external-id'] || null,
-  } as StorageCredential;
-}
-
-async function createWarehouseJSON(wh: CreateWarehouseRequest) {
-  try {
-    creatingWarehouse.value = true;
-    const cleaned = {
-      ...wh,
-      'storage-credential': cleanS3Credential(wh['storage-credential']),
-    };
-    const res: any = await functions.createWarehouse(cleaned, true);
-
-    if (res.status === 400) throw new Error(res.message);
-
-    emit('addedWarehouse');
-    creatingWarehouse.value = false;
-    isDialogActive.value = false;
-  } catch (error) {
-    creatingWarehouse.value = false;
-    handleError(error, 'createWarehouseJSON', true);
-  }
-}
-
 async function preloadWarehouseJSON(wh: CreateWarehouseRequest) {
   try {
     warehouseName.value = wh['warehouse-name'];
@@ -606,7 +577,7 @@ async function preloadWarehouseJSON(wh: CreateWarehouseRequest) {
         'storage-profile': wh['storage-profile'],
         'storage-credential': wh['storage-credential'],
       });
-    useFileInput.value = false;
+    importKey.value++;
   } catch (error) {
     console.error(error);
   }

--- a/src/components/WarehouseAddDialog.vue
+++ b/src/components/WarehouseAddDialog.vue
@@ -342,18 +342,23 @@ const slider = ref(7);
 const fileInputRef = ref<HTMLInputElement | null>(null);
 
 function handleFileImport(event: Event) {
-  const file = (event.target as HTMLInputElement).files?.[0];
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
   if (!file) return;
   const reader = new FileReader();
   reader.onload = (e) => {
     try {
       preloadWarehouseJSON(JSON.parse(e.target?.result as string));
     } catch (err) {
-      console.error('Error parsing JSON:', err);
+      handleError(err, 'importing warehouse JSON', true);
     }
+    input.value = '';
+  };
+  reader.onerror = () => {
+    handleError(reader.error || new Error('File read error'), 'reading warehouse JSON file', true);
+    input.value = '';
   };
   reader.readAsText(file);
-  (event.target as HTMLInputElement).value = '';
 }
 
 // const storageCredentialTypes = ref(['S3', 'GCS', 'AZURE']);

--- a/src/components/WarehouseHeader.vue
+++ b/src/components/WarehouseHeader.vue
@@ -105,6 +105,7 @@ async function renameWarehouse(name: string) {
   try {
     await functions.renameWarehouse(props.warehouseId, name, notify);
     await loadWarehouse();
+    visual.refreshWarehouseList();
   } catch (error) {
     console.error('Failed to rename warehouse:', error);
   }

--- a/src/components/WarehouseManager.vue
+++ b/src/components/WarehouseManager.vue
@@ -35,7 +35,7 @@
       <WarehouseAddDialog
         v-if="canCreateWarehouse"
         v-bind="addWarehouseProps"
-        @added-warehouse="listWarehouse" />
+        @added-warehouse="onWarehouseAdded" />
     </v-toolbar>
 
     <v-data-table
@@ -90,7 +90,7 @@
         <WarehouseAddDialog
           v-if="canCreateWarehouse"
           v-bind="addWarehouseProps"
-          @added-warehouse="listWarehouse" />
+          @added-warehouse="onWarehouseAdded" />
       </template>
     </v-data-table>
 
@@ -243,10 +243,14 @@ async function listWarehouse() {
         warehouse.can_delete = hasAction(warehouseAccess, 'delete');
       }),
     );
-    visual.refreshWarehouseList();
   } catch (error) {
     logError('listWarehouse', error);
   }
+}
+
+async function onWarehouseAdded() {
+  await listWarehouse();
+  visual.refreshWarehouseList();
 }
 
 function navigateToWarehouse(item: GetWarehouseResponseExtended) {
@@ -259,6 +263,7 @@ async function deleteWarehouse(id: string) {
   try {
     await functions.deleteWarehouse(id, notify);
     await listWarehouse();
+    visual.refreshWarehouseList();
   } catch (error) {
     logError('deleteWarehouse', error);
   }

--- a/src/components/WarehouseManager.vue
+++ b/src/components/WarehouseManager.vue
@@ -243,6 +243,7 @@ async function listWarehouse() {
         warehouse.can_delete = hasAction(warehouseAccess, 'delete');
       }),
     );
+    visual.refreshWarehouseList();
   } catch (error) {
     logError('listWarehouse', error);
   }

--- a/src/components/WarehousesNavigationTree.vue
+++ b/src/components/WarehousesNavigationTree.vue
@@ -1266,6 +1266,14 @@ watch(
   },
 );
 
+// Watch for warehouse list changes (rename, add) and reload the full warehouse list
+watch(
+  () => visualStore.warehouseListRefreshSignal,
+  async () => {
+    await loadWarehouses();
+  },
+);
+
 // Watch for navTreeRefreshSignal to reload specific nodes when objects are created/deleted
 watch(
   () => visualStore.navTreeRefreshSignal,

--- a/src/components/WarehousesNavigationTree.vue
+++ b/src/components/WarehousesNavigationTree.vue
@@ -1266,11 +1266,11 @@ watch(
   },
 );
 
-// Watch for warehouse list changes (rename, add) and reload the full warehouse list
+// Watch for warehouse list changes (rename, add, delete) — use refreshWarehouses to preserve expansion state
 watch(
   () => visualStore.warehouseListRefreshSignal,
   async () => {
-    await loadWarehouses();
+    await refreshWarehouses();
   },
 );
 

--- a/src/stores/visual.ts
+++ b/src/stores/visual.ts
@@ -110,6 +110,13 @@ export const useVisualStore = defineStore(
       };
     }
 
+    // Signal to tell WarehousesNavigationTree to reload the full warehouse list
+    const warehouseListRefreshSignal = ref(0);
+
+    function refreshWarehouseList() {
+      warehouseListRefreshSignal.value++;
+    }
+
     // Multi-tab SQL editor state - warehouse-specific
     // Key: warehouseId, Value: { activeTabId, tabs[] }
     const warehouseSqlData = ref<Record<string, WarehouseSqlData>>({});
@@ -369,6 +376,8 @@ export const useVisualStore = defineStore(
       warehouseTreeState,
       navTreeRefreshSignal,
       refreshNavTree,
+      warehouseListRefreshSignal,
+      refreshWarehouseList,
       offlineReason,
       setOfflineReason,
       clearOfflineReason,


### PR DESCRIPTION
## Summary
- Nav tree now refreshes when a warehouse is renamed or a new warehouse is added
- Replace JSON upload toggle with a direct "Import Warehouse" button in the add dialog
- Fix stale warehouse name in TablePreview after rename (closes #1722)

## Test plan
- Rename a warehouse → sidebar nav tree should immediately show the new name
- Add a new warehouse → sidebar nav tree should immediately show the new entry
- Rename a warehouse, then open the Preview tab on a table → header should show the new name

BEGIN_COMMIT_OVERRIDE
fix(ui): refresh nav tree on warehouse rename and add
fix(ui): replace JSON toggle with import warehouse button in add dialog
fix(ui): fix stale warehouse name in TablePreview after rename
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified warehouse import with dedicated file upload button for JSON configuration files.
  * Warehouse list now automatically updates after renaming or loading operations for real-time visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->