### PR TITLE
fix: normalize catalog URLs and add copy buttons in ServerOverview

### DIFF
--- a/src/components/ServerOverview.vue
+++ b/src/components/ServerOverview.vue
@@ -258,7 +258,25 @@
           <tr>
             <td class="font-weight-medium" style="width: 220px">Lakekeeper URL</td>
             <td>
-              <code>{{ appConfig.icebergCatalogUrl || '(auto-detected from browser)' }}</code>
+              <code>{{ functions ? functions.icebergCatalogUrl() : '(auto-detected from browser)' }}</code>
+              <v-btn
+                v-if="functions"
+                icon="mdi-content-copy"
+                size="x-small"
+                variant="text"
+                @click="copyToClipboard(functions.icebergCatalogUrl())"></v-btn>
+            </td>
+          </tr>
+          <tr>
+            <td class="font-weight-medium">Catalog URL</td>
+            <td>
+              <code>{{ functions ? functions.icebergCatalogUrlSuffixed() : '(not available)' }}</code>
+              <v-btn
+                v-if="functions"
+                icon="mdi-content-copy"
+                size="x-small"
+                variant="text"
+                @click="copyToClipboard(functions.icebergCatalogUrlSuffixed())"></v-btn>
             </td>
           </tr>
           <tr>
@@ -336,13 +354,8 @@ const appConfig = inject<any>('appConfig', {});
 const projectInfo = ref<any>({});
 
 async function copyToClipboard(text: string) {
-  try {
-    await navigator.clipboard.writeText(text);
-    if (functions && functions.showSnackbar) {
-      functions.showSnackbar('Copied to clipboard', 'success');
-    }
-  } catch (err) {
-    console.error('Failed to copy:', err);
+  if (functions?.copyToClipboard) {
+    await functions.copyToClipboard(text);
   }
 }
 

--- a/src/components/ServerOverview.vue
+++ b/src/components/ServerOverview.vue
@@ -258,7 +258,9 @@
           <tr>
             <td class="font-weight-medium" style="width: 220px">Lakekeeper URL</td>
             <td>
-              <code>{{ functions ? functions.icebergCatalogUrl() : '(auto-detected from browser)' }}</code>
+              <code>
+                {{ functions ? functions.icebergCatalogUrl() : '(auto-detected from browser)' }}
+              </code>
               <v-btn
                 v-if="functions"
                 icon="mdi-content-copy"
@@ -270,7 +272,9 @@
           <tr>
             <td class="font-weight-medium">Catalog URL</td>
             <td>
-              <code>{{ functions ? functions.icebergCatalogUrlSuffixed() : '(not available)' }}</code>
+              <code>
+                {{ functions ? functions.icebergCatalogUrlSuffixed() : '(not available)' }}
+              </code>
               <v-btn
                 v-if="functions"
                 icon="mdi-content-copy"


### PR DESCRIPTION
## Summary

- Show normalized Lakekeeper URL via `functions.icebergCatalogUrl()` instead of raw `appConfig.icebergCatalogUrl` — fixes display inconsistency when Lakekeeper backend normalizes `LAKEKEEPER__BASE_URI` by adding a trailing slash
- Add new **Catalog URL** row showing `functions.icebergCatalogUrlSuffixed()` — the actual URL used for API and DuckDB/preview calls
- Add copy buttons to both URL rows using `functions.copyToClipboard()` (which triggers the snackbar) instead of the broken local implementation that checked the non-existent `functions.showSnackbar`

## Test plan

- [ ] Open Server Settings → Overview tab
- [ ] Lakekeeper URL shows normalized URL (with trailing slash)
- [ ] Catalog URL row shows e.g. `http://localhost:8181/catalog/`
- [ ] Copy buttons on both rows work and show snackbar confirmation
- [ ] Test with `LAKEKEEPER__BASE_URI` set and unset

BEGIN_COMMIT_OVERRIDE
fix(ui): normalize catalog URLs and add copy buttons in ServerOverview
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy buttons for Lakekeeper URL and new Catalog URL field
  * Enhanced clipboard functionality for streamlined URL management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->