### PR TITLE
fix: detach LoQE catalog on warehouse rename

### DIFF
--- a/src/components/WarehouseHeader.vue
+++ b/src/components/WarehouseHeader.vue
@@ -35,9 +35,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, watch, onMounted, computed } from 'vue';
+import { ref, reactive, watch, onMounted, computed, inject } from 'vue';
 import { useFunctions } from '@/plugins/functions';
 import { useVisualStore } from '@/stores/visual';
+import { useLoQE } from '@/composables/useLoQE';
 import type {
   GetWarehouseResponse,
   StorageCredential,
@@ -53,6 +54,8 @@ const props = defineProps<{
 
 const functions = useFunctions();
 const visual = useVisualStore();
+const appConfig = inject<{ baseUrlPrefix?: string }>('appConfig', {});
+const loqe = useLoQE({ baseUrlPrefix: appConfig.baseUrlPrefix ?? '' });
 const notify = true;
 const processStatus = ref('starting');
 
@@ -102,10 +105,21 @@ async function loadWarehouse() {
 }
 
 async function renameWarehouse(name: string) {
+  const previousName = warehouse.name;
   try {
     await functions.renameWarehouse(props.warehouseId, name, notify);
     await loadWarehouse();
     visual.refreshWarehouseList();
+    if (previousName && previousName !== name) {
+      // DuckDB ATTACHes catalogs by warehouse name; detach the stale
+      // entry (and its persisted Pinia record) so it isn't re-attached
+      // alongside the renamed catalog on the next preview/reload.
+      try {
+        await loqe.detachCatalog(previousName);
+      } catch (e) {
+        console.warn('Failed to detach renamed catalog from LoQE:', e);
+      }
+    }
   } catch (error) {
     console.error('Failed to rename warehouse:', error);
   }

--- a/src/components/WarehouseHeader.vue
+++ b/src/components/WarehouseHeader.vue
@@ -114,10 +114,14 @@ async function renameWarehouse(name: string) {
       // DuckDB ATTACHes catalogs by warehouse name; detach the stale
       // entry (and its persisted Pinia record) so it isn't re-attached
       // alongside the renamed catalog on the next preview/reload.
+      // Best-effort: the rename itself already succeeded (and the
+      // success snackbar fired), and a stale ATTACH at worst causes
+      // one extra /catalog/v1/config request until next reload —
+      // not worth bugging the user with a follow-up error snackbar.
       try {
         await loqe.detachCatalog(previousName);
       } catch (e) {
-        console.warn('Failed to detach renamed catalog from LoQE:', e);
+        logError(`WarehouseHeader.renameWarehouse.detach(${previousName})`, e);
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Summary

Renaming a warehouse left the old DuckDB ATTACH alive and the old name persisted in `localStorage.loqe.attachedCatalogs`. DuckDB kept issuing `/catalog/v1/config?warehouse=…/<oldname>` alongside the new name on every preview render and got reattached on page reload via `useLoQE.initialize()`.

`WarehouseHeader.renameWarehouse` now captures the previous warehouse name before calling the rename API and, on success, calls `loqe.detachCatalog(previousName)`. That issues `DETACH DATABASE`, drops the associated secret, and removes the persisted Pinia record. Wrapped in `try/catch` so a LoQE failure can't mask a successful rename.

## Test plan

- [ ] Open `TablePreview` for `demo-sts` (creates the ATTACH).
- [ ] Rename `demo-sts` → `demo-sts1` from the actions menu.
- [ ] Reopen preview → only one `/catalog/v1/config?warehouse=…/demo-sts1` call fires.
- [ ] Hard reload → `localStorage.loqe.attachedCatalogs` no longer lists `demo-sts`.
- [ ] Rename a warehouse you've never previewed → no error (engine not initialized → no-op detach).

BEGIN_COMMIT_OVERRIDE
fix(ui): detach LoQE catalog on warehouse rename
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Warehouse rename operations now properly manage associated catalogs and metadata when warehouse names change, with improved error handling to ensure operations complete reliably without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->