### PR TITLE
feat: server overview revamp with support bundle and feedback dialogs

### DIFF
--- a/openapi/management-open-api.yaml
+++ b/openapi/management-open-api.yaml
@@ -3934,6 +3934,27 @@ components:
         allowed:
           type: boolean
           description: Whether the action is allowed.
+    ConsoleInfo:
+      type: object
+      description: Information about the UI (console) shipped with this binary.
+      required:
+        - edition
+        - version
+      properties:
+        commit-sha:
+          type:
+            - string
+            - 'null'
+          description: Git commit SHA of the console source, if known.
+        edition:
+          type: string
+          description: |-
+            Edition / crate name of the bundled console.
+            e.g. `lakekeeper-console` for the OSS console or
+            `lakekeeper-console-plus` for the enterprise console.
+        version:
+          type: string
+          description: SemVer of the console crate.
     ControlTaskAction:
       oneOf:
         - type: object
@@ -6827,6 +6848,7 @@ components:
       type: object
       required:
         - version
+        - lakekeeper-version
         - bootstrapped
         - server-id
         - authz-backend
@@ -6848,6 +6870,11 @@ components:
         bootstrapped:
           type: boolean
           description: Whether the catalog has been bootstrapped.
+        console:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/ConsoleInfo'
+              description: Information about the bundled console (UI), if any.
         default-project-id:
           type:
             - string
@@ -6856,6 +6883,30 @@ components:
         gcp-system-identities-enabled:
           type: boolean
           description: If using GCP system identities for GCS storage profiles are enabled.
+        lakekeeper-commit-sha:
+          type:
+            - string
+            - 'null'
+          description: |-
+            Git commit SHA of the upstream `lakekeeper` crate, if the binary
+            reported it at build time.
+        lakekeeper-enterprise-commit-sha:
+          type:
+            - string
+            - 'null'
+          description: Git commit SHA of the enterprise binary, if known.
+        lakekeeper-enterprise-version:
+          type:
+            - string
+            - 'null'
+          description: |-
+            SemVer of the enterprise binary (e.g. `lakekeeper-plus`) when this
+            server is an enterprise build. `None` on OSS builds.
+        lakekeeper-version:
+          type: string
+          description: |-
+            SemVer of the upstream `lakekeeper` crate the server was built
+            against.
         license-status:
           $ref: '#/components/schemas/LicenseStatus'
           description: License status information
@@ -6872,7 +6923,11 @@ components:
             Returns null if the catalog has not been bootstrapped.
         version:
           type: string
-          description: Version of the server.
+          description: |-
+            Deprecated alias of `lakekeeper-version`. Always equal to it; kept
+            for clients that read the plain `version` field. New clients should
+            read `lakekeeper-version` and/or `lakekeeper-enterprise-version`.
+          deprecated: true
     ServerRelation:
       type: string
       enum:
@@ -6943,8 +6998,8 @@ components:
                 let cred: StorageCredential = serde_json::from_str(r#"{
                     "type": "s3",
                     "credential-type": "access-key",
-                    "aws-access-key-id": "minio-root-user",
-                    "aws-secret-access-key": "minio-root-password"
+                    "access-key-id": "minio-root-user",
+                    "secret-access-key": "minio-root-password"
                   }"#).unwrap();
                 ```
             - type: object
@@ -6966,8 +7021,8 @@ components:
             let cred: StorageCredential = serde_json::from_str(r#"{
                 "type": "s3",
                 "credential-type": "access-key",
-                "aws-access-key-id": "minio-root-user",
-                "aws-secret-access-key": "minio-root-password"
+                "access-key-id": "minio-root-user",
+                "secret-access-key": "minio-root-password"
               }"#).unwrap();
             ```
         - allOf:
@@ -7713,7 +7768,9 @@ components:
             Storage profile to use for the warehouse.
             The new profile must point to the same location as the existing profile
             to avoid data loss. For S3 this means that you may not change the
-            bucket or key prefix. The region may only be changed if an endpoint is set.
+            bucket or key prefix. The region may only be changed if an `endpoint`
+            is set on the new profile (so the endpoint, not the region, determines
+            where S3 requests are routed).
     User:
       type: object
       description: User of the catalog

--- a/package-lock.json
+++ b/package-lock.json
@@ -1303,9 +1303,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1321,9 +1318,6 @@
       "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1341,9 +1335,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1359,9 +1350,6 @@
       "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1379,9 +1367,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1397,9 +1382,6 @@
       "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -47,9 +47,15 @@
           <v-list-item prepend-icon="mdi-face-agent" @click="goToSupport">
             <v-list-item-title>Support</v-list-item-title>
           </v-list-item>
+          <v-divider class="my-1"></v-divider>
+          <v-list-item prepend-icon="mdi-export-variant" @click="supportBundleOpen = true">
+            <v-list-item-title>Export for GitHub</v-list-item-title>
+          </v-list-item>
         </v-list>
       </v-menu>
     </slot>
+
+    <SupportBundleDialog v-model="supportBundleOpen" />
 
     <v-menu v-if="showUserMenu" open-on-hover>
       <template #activator="{ props }">
@@ -97,11 +103,27 @@
       variant="text"
       @click="toggleTheme"></v-btn>
 
+    <!-- Feedback button (OSS only) -->
+    <v-tooltip v-if="!isEnterpriseEdition" location="bottom" text="Share feedback">
+      <template #activator="{ props: tipProps }">
+        <v-btn
+          v-bind="tipProps"
+          icon="mdi-message-text"
+          size="small"
+          class="ml-2"
+          variant="text"
+          @click="feedbackOpen = true"></v-btn>
+      </template>
+    </v-tooltip>
+
     <!-- Notification Panel -->
     <NotificationPanel />
 
     <!-- Token Dialog -->
     <TokenDialog ref="tokenDialog" />
+
+    <!-- Feedback Dialog (OSS only) -->
+    <FeedbackDialog v-if="!isEnterpriseEdition" v-model="feedbackOpen" />
   </v-app-bar>
 </template>
 
@@ -116,6 +138,14 @@ import { useRouter } from 'vue-router';
 import LogoDark from '@/assets/LAKEKEEPER_IMAGE_TEXT_SIDE.svg';
 import LogoLight from '@/assets/LAKEKEEPER_IMAGE_TEXT_WHITE_SIDE.svg';
 import TokenDialog from './TokenDialog.vue';
+import SupportBundleDialog from './SupportBundleDialog.vue';
+import FeedbackDialog from './FeedbackDialog.vue';
+
+const supportBundleOpen = ref(false);
+const feedbackOpen = ref(false);
+
+const appConfigInjected = inject<any>('appConfig', {});
+const isEnterpriseEdition = computed(() => appConfigInjected?.edition === 'enterprise');
 
 // Props
 const props = defineProps({

--- a/src/components/FeedbackDialog.vue
+++ b/src/components/FeedbackDialog.vue
@@ -1,0 +1,143 @@
+<template>
+  <v-dialog
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+    max-width="600">
+    <v-card>
+      <v-toolbar color="transparent" density="compact" flat>
+        <v-toolbar-title class="text-subtitle-1">
+          <v-icon class="mr-2" color="primary">mdi-message-text</v-icon>
+          Share Your Feedback
+        </v-toolbar-title>
+        <v-spacer></v-spacer>
+        <v-btn
+          icon="mdi-close"
+          size="small"
+          variant="text"
+          @click="$emit('update:modelValue', false)"></v-btn>
+      </v-toolbar>
+      <v-divider></v-divider>
+      <v-card-text>
+        <p class="text-body-2 mb-4">
+          Help us improve Lakekeeper. Your answers will be inserted into an email draft — review and
+          edit before sending.
+        </p>
+
+        <div class="mb-5">
+          <div class="text-body-2 mb-1">
+            How is your experience with Lakekeeper?
+            <strong class="ml-1">{{ rating }}/10</strong>
+          </div>
+          <v-slider
+            v-model="rating"
+            :min="1"
+            :max="10"
+            :step="1"
+            thumb-label
+            show-ticks="always"
+            tick-size="3"
+            hide-details></v-slider>
+        </div>
+
+        <v-select
+          v-model="discovery"
+          label="How did you find Lakekeeper? *"
+          :items="discoveryOptions"
+          :rules="[(v) => !!v || 'Required']"
+          density="compact"
+          variant="outlined"
+          class="mb-2"></v-select>
+
+        <v-text-field
+          v-if="discovery === 'Other'"
+          v-model="discoveryOther"
+          label="Please specify *"
+          :rules="[(v) => !!v.trim() || 'Required']"
+          density="compact"
+          variant="outlined"
+          class="mb-2"></v-text-field>
+
+        <v-textarea
+          v-model="improvements"
+          label="What improvements would you like to propose? *"
+          :counter="2000"
+          maxlength="2000"
+          :rules="[(v) => !!v.trim() || 'Required']"
+          density="compact"
+          variant="outlined"
+          rows="5"></v-textarea>
+      </v-card-text>
+      <v-divider></v-divider>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn variant="text" @click="$emit('update:modelValue', false)">Cancel</v-btn>
+        <v-btn
+          color="primary"
+          variant="tonal"
+          prepend-icon="mdi-email-fast"
+          :disabled="!isValid"
+          @click="sendFeedback">
+          Send Feedback
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+const FEEDBACK_EMAIL = 'info@vakamo.com';
+
+defineProps<{ modelValue: boolean }>();
+const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void }>();
+
+const rating = ref(8);
+const discovery = ref<string | null>(null);
+const discoveryOther = ref('');
+const improvements = ref('');
+
+const isValid = computed(() => {
+  if (!discovery.value) return false;
+  if (discovery.value === 'Other' && !discoveryOther.value.trim()) return false;
+  if (!improvements.value.trim()) return false;
+  return true;
+});
+
+const discoveryOptions = [
+  'GitHub',
+  'Reddit / Hacker News',
+  'Blog post',
+  'Conference / Meetup',
+  'Word of mouth',
+  'Search engine',
+  'Other',
+];
+
+function sendFeedback() {
+  const discoveryLabel =
+    discovery.value === 'Other'
+      ? `Other: ${discoveryOther.value || '(not specified)'}`
+      : (discovery.value ?? '(not specified)');
+
+  const lines = [
+    'Hello Lakekeeper Team,',
+    '',
+    'Here is my feedback:',
+    '',
+    `Rating: ${rating.value}/10`,
+    `Discovery: ${discoveryLabel}`,
+    '',
+    'Improvements:',
+    improvements.value || '(none)',
+  ];
+  const body = lines.join('\n');
+
+  const mailto =
+    `mailto:${FEEDBACK_EMAIL}` +
+    `?subject=${encodeURIComponent('Lakekeeper Feedback')}` +
+    `&body=${encodeURIComponent(body)}`;
+  window.location.href = mailto;
+  emit('update:modelValue', false);
+}
+</script>

--- a/src/components/ServerOverview.vue
+++ b/src/components/ServerOverview.vue
@@ -1,78 +1,161 @@
 <template>
   <v-container fluid class="pa-4" style="max-height: calc(100vh - 200px); overflow-y: auto">
-    <!-- Server Information -->
-    <v-card class="mb-4" elevation="1">
-      <v-toolbar color="transparent" density="compact" flat>
-        <v-toolbar-title class="text-subtitle-1">
-          <v-icon class="mr-2" color="primary">mdi-server</v-icon>
-          Server Information
-        </v-toolbar-title>
-        <v-spacer></v-spacer>
-        <v-chip
-          v-if="projectInfo.version"
-          size="small"
-          color="primary"
-          variant="outlined"
-          class="mr-2">
-          v{{ projectInfo.version }}
-        </v-chip>
-      </v-toolbar>
-      <v-divider></v-divider>
-      <v-table density="compact">
-        <tbody>
-          <tr>
-            <td class="font-weight-medium" style="width: 220px">Server ID</td>
-            <td>
-              {{ projectInfo['server-id'] || 'N/A' }}
-              <v-btn
-                v-if="projectInfo['server-id']"
-                icon="mdi-content-copy"
-                size="x-small"
-                variant="text"
-                @click="copyToClipboard(projectInfo['server-id'])"></v-btn>
-            </td>
-          </tr>
-          <tr>
-            <td class="font-weight-medium">Version</td>
-            <td>{{ projectInfo.version || 'N/A' }}</td>
-          </tr>
-          <tr>
-            <td class="font-weight-medium">Bootstrap Status</td>
-            <td>
-              <v-chip
-                :color="projectInfo.bootstrapped ? 'success' : 'warning'"
-                size="small"
-                variant="flat">
-                <v-icon start>
-                  {{ projectInfo.bootstrapped ? 'mdi-check' : 'mdi-alert' }}
-                </v-icon>
-                {{ projectInfo.bootstrapped ? 'Bootstrapped' : 'Not Bootstrapped' }}
-              </v-chip>
-            </td>
-          </tr>
-          <tr>
-            <td class="font-weight-medium">Default Project ID</td>
-            <td>
-              {{ projectInfo['default-project-id'] || 'N/A' }}
-              <v-btn
-                v-if="projectInfo['default-project-id']"
-                icon="mdi-content-copy"
-                size="x-small"
-                variant="text"
-                @click="copyToClipboard(projectInfo['default-project-id'])"></v-btn>
-            </td>
-          </tr>
-          <tr>
-            <td class="font-weight-medium">Authorization Backend</td>
-            <td>
-              <v-chip size="small" color="info">
-                {{ projectInfo['authz-backend'] || 'N/A' }}
-              </v-chip>
-            </td>
-          </tr>
-        </tbody>
-      </v-table>
-    </v-card>
+    <!-- Export bundle (available in both OSS and Enterprise editions) -->
+    <div class="d-flex justify-end mb-3">
+      <v-btn
+        prepend-icon="mdi-export-variant"
+        variant="tonal"
+        color="primary"
+        size="small"
+        @click="exportDialog = true">
+        {{ isEnterpriseConsole ? 'Export for Support' : 'Export for GitHub' }}
+      </v-btn>
+    </div>
+
+    <SupportBundleDialog v-model="exportDialog" />
+
+    <!-- Server Information + Console side by side -->
+    <v-row class="mb-4">
+      <v-col cols="12" :md="projectInfo.console ? 6 : 12">
+        <v-card elevation="1" class="fill-height">
+          <v-toolbar color="transparent" density="compact" flat>
+            <v-toolbar-title class="text-subtitle-1">
+              <v-icon class="mr-2" color="primary">mdi-server</v-icon>
+              Server Information
+            </v-toolbar-title>
+            <v-spacer></v-spacer>
+            <v-chip
+              v-if="projectInfo['lakekeeper-version']"
+              size="small"
+              color="primary"
+              variant="outlined"
+              class="mr-2">
+              v{{ projectInfo['lakekeeper-version'] }}
+            </v-chip>
+          </v-toolbar>
+          <v-divider></v-divider>
+          <v-table density="compact">
+            <tbody>
+              <tr>
+                <td class="font-weight-medium" style="width: 220px">Server ID</td>
+                <td>
+                  {{ projectInfo['server-id'] || 'N/A' }}
+                  <v-btn
+                    v-if="projectInfo['server-id']"
+                    icon="mdi-content-copy"
+                    size="x-small"
+                    variant="text"
+                    @click="copyToClipboard(projectInfo['server-id'])"></v-btn>
+                </td>
+              </tr>
+              <tr v-if="!isEnterpriseConsole">
+                <td class="font-weight-medium">Lakekeeper Version</td>
+                <td>
+                  {{ projectInfo['lakekeeper-version'] || 'N/A' }}
+                  <span
+                    v-if="projectInfo['lakekeeper-commit-sha']"
+                    class="text-medium-emphasis ml-2">
+                    ({{ shortSha(projectInfo['lakekeeper-commit-sha']) }})
+                  </span>
+                </td>
+              </tr>
+              <tr v-if="isEnterpriseConsole && projectInfo['lakekeeper-enterprise-version']">
+                <td class="font-weight-medium">Enterprise Version</td>
+                <td>
+                  {{ projectInfo['lakekeeper-enterprise-version'] }}
+                  <span
+                    v-if="projectInfo['lakekeeper-enterprise-commit-sha']"
+                    class="text-medium-emphasis ml-2">
+                    ({{ shortSha(projectInfo['lakekeeper-enterprise-commit-sha']) }})
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <td class="font-weight-medium">Bootstrap Status</td>
+                <td>
+                  <v-chip
+                    :color="projectInfo.bootstrapped ? 'success' : 'warning'"
+                    size="small"
+                    variant="flat">
+                    <v-icon start>
+                      {{ projectInfo.bootstrapped ? 'mdi-check' : 'mdi-alert' }}
+                    </v-icon>
+                    {{ projectInfo.bootstrapped ? 'Bootstrapped' : 'Not Bootstrapped' }}
+                  </v-chip>
+                </td>
+              </tr>
+              <tr>
+                <td class="font-weight-medium">Default Project ID</td>
+                <td>
+                  {{ projectInfo['default-project-id'] || 'N/A' }}
+                  <v-btn
+                    v-if="projectInfo['default-project-id']"
+                    icon="mdi-content-copy"
+                    size="x-small"
+                    variant="text"
+                    @click="copyToClipboard(projectInfo['default-project-id'])"></v-btn>
+                </td>
+              </tr>
+              <tr>
+                <td class="font-weight-medium">Authorization Backend</td>
+                <td>
+                  <v-chip size="small" color="info">
+                    {{ projectInfo['authz-backend'] || 'N/A' }}
+                  </v-chip>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card>
+      </v-col>
+
+      <!-- Console -->
+      <v-col v-if="projectInfo.console" cols="12" md="6">
+        <v-card elevation="1" class="fill-height">
+          <v-toolbar color="transparent" density="compact" flat>
+            <v-toolbar-title class="text-subtitle-1">
+              <v-icon class="mr-2" color="primary">mdi-monitor-dashboard</v-icon>
+              Console
+            </v-toolbar-title>
+            <v-spacer></v-spacer>
+            <v-chip
+              v-if="projectInfo.console.version"
+              size="small"
+              color="primary"
+              variant="outlined"
+              class="mr-2">
+              v{{ projectInfo.console.version }}
+            </v-chip>
+          </v-toolbar>
+          <v-divider></v-divider>
+          <v-table density="compact">
+            <tbody>
+              <tr>
+                <td class="font-weight-medium" style="width: 220px">Edition</td>
+                <td>
+                  <v-chip size="small" color="info">{{ projectInfo.console.edition }}</v-chip>
+                </td>
+              </tr>
+              <tr>
+                <td class="font-weight-medium">Version</td>
+                <td>{{ projectInfo.console.version || 'N/A' }}</td>
+              </tr>
+              <tr v-if="projectInfo.console['commit-sha']">
+                <td class="font-weight-medium">Commit SHA</td>
+                <td>
+                  <code>{{ shortSha(projectInfo.console['commit-sha']) }}</code>
+                  <v-btn
+                    icon="mdi-content-copy"
+                    size="x-small"
+                    variant="text"
+                    @click="copyToClipboard(projectInfo.console['commit-sha']!)"></v-btn>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-card>
+      </v-col>
+    </v-row>
 
     <!-- License & Cloud Identities side by side -->
     <v-row class="mb-4">
@@ -289,6 +372,17 @@
               <code>{{ appConfig.baseUrlPrefix || '(none)' }}</code>
             </td>
           </tr>
+          <tr v-if="appConfig.enabledUserSurveys !== undefined">
+            <td class="font-weight-medium">User Surveys</td>
+            <td>
+              <v-chip
+                :color="appConfig.enabledUserSurveys ? 'success' : 'grey'"
+                size="small"
+                variant="flat">
+                {{ appConfig.enabledUserSurveys ? 'Enabled' : 'Disabled' }}
+              </v-chip>
+            </td>
+          </tr>
           <tr>
             <td class="font-weight-medium">Authentication</td>
             <td>
@@ -351,11 +445,17 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted, ref, inject } from 'vue';
+import { onMounted, ref, computed, inject } from 'vue';
+import type { ServerInfo } from '@/gen/management/types.gen';
+import SupportBundleDialog from './SupportBundleDialog.vue';
 
 const functions = inject<any>('functions');
 const appConfig = inject<any>('appConfig', {});
-const projectInfo = ref<any>({});
+const projectInfo = ref<Partial<ServerInfo>>({});
+
+const isEnterpriseConsole = computed(() => appConfig?.edition === 'enterprise');
+
+const exportDialog = ref(false);
 
 async function copyToClipboard(text: string) {
   if (functions?.copyToClipboard) {
@@ -381,6 +481,10 @@ function getExpirationColor(expirationDate: string): string {
   if (daysUntilExpiration < 30) return 'warning'; // Less than 30 days
   if (daysUntilExpiration < 90) return 'orange'; // Less than 90 days
   return 'success'; // More than 90 days
+}
+
+function shortSha(sha: string | null | undefined): string {
+  return sha ? sha.slice(0, 7) : '';
 }
 
 function formatDate(dateString: string): string {

--- a/src/components/ServerOverview.vue
+++ b/src/components/ServerOverview.vue
@@ -59,10 +59,10 @@
                   </span>
                 </td>
               </tr>
-              <tr v-if="isEnterpriseConsole && projectInfo['lakekeeper-enterprise-version']">
+              <tr v-if="isEnterpriseConsole">
                 <td class="font-weight-medium">Enterprise Version</td>
                 <td>
-                  {{ projectInfo['lakekeeper-enterprise-version'] }}
+                  {{ projectInfo['lakekeeper-enterprise-version'] || 'N/A' }}
                   <span
                     v-if="projectInfo['lakekeeper-enterprise-commit-sha']"
                     class="text-medium-emphasis ml-2">

--- a/src/components/SupportBundleDialog.vue
+++ b/src/components/SupportBundleDialog.vue
@@ -1,0 +1,145 @@
+<template>
+  <v-dialog
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+    max-width="800">
+    <v-card>
+      <v-toolbar color="transparent" density="compact" flat>
+        <v-toolbar-title class="text-subtitle-1">
+          <v-icon class="mr-2" color="primary">mdi-export-variant</v-icon>
+          {{ title }}
+        </v-toolbar-title>
+        <v-spacer></v-spacer>
+        <v-btn
+          icon="mdi-close"
+          size="small"
+          variant="text"
+          @click="$emit('update:modelValue', false)"></v-btn>
+      </v-toolbar>
+      <v-divider></v-divider>
+      <v-card-text>
+        <p class="text-body-2 mb-3">
+          {{ description }}
+        </p>
+        <v-textarea
+          :model-value="supportBundleJson"
+          readonly
+          variant="outlined"
+          density="compact"
+          rows="14"
+          no-resize
+          class="font-mono text-caption"></v-textarea>
+      </v-card-text>
+      <v-divider></v-divider>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn prepend-icon="mdi-content-copy" variant="text" @click="copySupportBundle">
+          Copy to Clipboard
+        </v-btn>
+        <v-btn
+          prepend-icon="mdi-download"
+          color="primary"
+          variant="tonal"
+          @click="downloadSupportBundle">
+          Download JSON
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref, watch } from 'vue';
+import type { ServerInfo } from '@/gen/management/types.gen';
+
+const props = defineProps<{
+  modelValue: boolean;
+}>();
+
+defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+}>();
+
+const functions = inject<any>('functions');
+const appConfig = inject<any>('appConfig', {});
+
+const projectInfo = ref<Partial<ServerInfo>>({});
+
+const isEnterprise = computed(() => appConfig?.edition === 'enterprise');
+
+const title = computed(() => (isEnterprise.value ? 'Support Bundle' : 'GitHub Issue Bundle'));
+
+const description = computed(() =>
+  isEnterprise.value
+    ? 'Share this bundle when contacting support. It contains server info and UI configuration; no tokens or credentials are included.'
+    : 'Attach this bundle when opening a GitHub issue. It contains server info and UI configuration; no tokens or credentials are included.',
+);
+
+const supportBundleJson = computed(() =>
+  JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      app: {
+        edition: appConfig?.edition ?? 'unknown',
+        url: typeof window !== 'undefined' ? window.location.href : null,
+        userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+      },
+      serverInfo: projectInfo.value,
+      uiConfig: {
+        icebergCatalogUrl: appConfig?.icebergCatalogUrl,
+        baseUrlPrefix: appConfig?.baseUrlPrefix,
+        enabledAuthentication: appConfig?.enabledAuthentication,
+        enabledPermissions: appConfig?.enabledPermissions,
+        enabledUserSurveys: appConfig?.enabledUserSurveys,
+        idpAuthority: appConfig?.idpAuthority,
+        idpClientId: appConfig?.idpClientId,
+        idpScope: appConfig?.idpScope,
+        idpResource: appConfig?.idpResource,
+        idpTokenType: appConfig?.idpTokenType,
+        idpRedirectPath: appConfig?.idpRedirectPath,
+        idpLogoutRedirectPath: appConfig?.idpLogoutRedirectPath,
+      },
+    },
+    null,
+    2,
+  ),
+);
+
+async function loadServerInfo() {
+  if (!functions?.getServerInfo) return;
+  try {
+    projectInfo.value = await functions.getServerInfo();
+  } catch {
+    // Fail silently — bundle just won't include serverInfo
+  }
+}
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) loadServerInfo();
+  },
+);
+
+async function copySupportBundle() {
+  if (functions?.copyToClipboard) {
+    await functions.copyToClipboard(supportBundleJson.value);
+  } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
+    await navigator.clipboard.writeText(supportBundleJson.value);
+  }
+}
+
+function downloadSupportBundle() {
+  const blob = new Blob([supportBundleJson.value], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const serverId = projectInfo.value['server-id'] || 'lakekeeper';
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `lakekeeper-support-${serverId}-${stamp}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+</script>

--- a/src/components/SupportBundleDialog.vue
+++ b/src/components/SupportBundleDialog.vue
@@ -51,6 +51,7 @@
 <script setup lang="ts">
 import { computed, inject, ref, watch } from 'vue';
 import type { ServerInfo } from '@/gen/management/types.gen';
+import { useFunctions } from '@/plugins/functions';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -60,8 +61,18 @@ defineEmits<{
   (e: 'update:modelValue', value: boolean): void;
 }>();
 
-const functions = inject<any>('functions');
+const functions = useFunctions();
 const appConfig = inject<any>('appConfig', {});
+
+function sanitizedUrl(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const u = new URL(window.location.href);
+    return u.origin + u.pathname;
+  } catch {
+    return null;
+  }
+}
 
 const projectInfo = ref<Partial<ServerInfo>>({});
 
@@ -81,7 +92,7 @@ const supportBundleJson = computed(() =>
       generatedAt: new Date().toISOString(),
       app: {
         edition: appConfig?.edition ?? 'unknown',
-        url: typeof window !== 'undefined' ? window.location.href : null,
+        url: sanitizedUrl(),
         userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
       },
       serverInfo: projectInfo.value,
@@ -109,8 +120,8 @@ async function loadServerInfo() {
   if (!functions?.getServerInfo) return;
   try {
     projectInfo.value = await functions.getServerInfo();
-  } catch {
-    // Fail silently — bundle just won't include serverInfo
+  } catch (error) {
+    functions?.handleError?.(error, 'loading server info', true);
   }
 }
 
@@ -122,10 +133,14 @@ watch(
 );
 
 async function copySupportBundle() {
-  if (functions?.copyToClipboard) {
-    await functions.copyToClipboard(supportBundleJson.value);
-  } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
-    await navigator.clipboard.writeText(supportBundleJson.value);
+  try {
+    if (functions?.copyToClipboard) {
+      functions.copyToClipboard(supportBundleJson.value);
+    } else if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      await navigator.clipboard.writeText(supportBundleJson.value);
+    }
+  } catch (error) {
+    functions?.handleError?.(error, 'copySupportBundle', true);
   }
 }
 

--- a/src/gen/management/types.gen.ts
+++ b/src/gen/management/types.gen.ts
@@ -203,6 +203,26 @@ export type CheckResponse = {
     allowed: boolean;
 };
 
+/**
+ * Information about the UI (console) shipped with this binary.
+ */
+export type ConsoleInfo = {
+    /**
+     * Git commit SHA of the console source, if known.
+     */
+    'commit-sha'?: string | null;
+    /**
+     * Edition / crate name of the bundled console.
+     * e.g. `lakekeeper-console` for the OSS console or
+     * `lakekeeper-console-plus` for the enterprise console.
+     */
+    edition: string;
+    /**
+     * SemVer of the console crate.
+     */
+    version: string;
+};
+
 export type ControlTaskAction = {
     'action-type': 'stop';
 } | {
@@ -1704,6 +1724,7 @@ export type ServerInfo = {
      * Whether the catalog has been bootstrapped.
      */
     bootstrapped: boolean;
+    console?: null | ConsoleInfo;
     /**
      * Default Project ID. Null if not set
      */
@@ -1712,6 +1733,25 @@ export type ServerInfo = {
      * If using GCP system identities for GCS storage profiles are enabled.
      */
     'gcp-system-identities-enabled': boolean;
+    /**
+     * Git commit SHA of the upstream `lakekeeper` crate, if the binary
+     * reported it at build time.
+     */
+    'lakekeeper-commit-sha'?: string | null;
+    /**
+     * Git commit SHA of the enterprise binary, if known.
+     */
+    'lakekeeper-enterprise-commit-sha'?: string | null;
+    /**
+     * SemVer of the enterprise binary (e.g. `lakekeeper-plus`) when this
+     * server is an enterprise build. `None` on OSS builds.
+     */
+    'lakekeeper-enterprise-version'?: string | null;
+    /**
+     * SemVer of the upstream `lakekeeper` crate the server was built
+     * against.
+     */
+    'lakekeeper-version': string;
     /**
      * License status information
      */
@@ -1726,7 +1766,11 @@ export type ServerInfo = {
      */
     'server-id': string;
     /**
-     * Version of the server.
+     * Deprecated alias of `lakekeeper-version`. Always equal to it; kept
+     * for clients that read the plain `version` field. New clients should
+     * read `lakekeeper-version` and/or `lakekeeper-enterprise-version`.
+     *
+     * @deprecated
      */
     version: string;
 };
@@ -2078,7 +2122,9 @@ export type UpdateWarehouseStorageRequest = {
      * Storage profile to use for the warehouse.
      * The new profile must point to the same location as the existing profile
      * to avoid data loss. For S3 this means that you may not change the
-     * bucket or key prefix. The region may only be changed if an endpoint is set.
+     * bucket or key prefix. The region may only be changed if an `endpoint`
+     * is set on the new profile (so the endpoint, not the region, determines
+     * where S3 requests are routed).
      */
     'storage-profile': StorageProfile;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,8 @@ import DeleteDialog from './components/DeleteDialog.vue';
 import EntityPropertiesDialog from './components/EntityPropertiesDialog.vue';
 import TaskConfigDialog from './components/TaskConfigDialog.vue';
 import ServerOverview from './components/ServerOverview.vue';
+import SupportBundleDialog from './components/SupportBundleDialog.vue';
+import FeedbackDialog from './components/FeedbackDialog.vue';
 import UserManager from './components/UserManager.vue';
 import StatisticsDialog from './components/StatisticsDialog.vue';
 import StatisticsProject from './components/StatisticsProject.vue';
@@ -95,6 +97,8 @@ export {
   EntityPropertiesDialog,
   TaskConfigDialog,
   ServerOverview,
+  SupportBundleDialog,
+  FeedbackDialog,
   UserManager,
   ProjectNameAddOrEditDialog,
   AuthenticationDisabledWarningBanner,
@@ -255,6 +259,8 @@ const components = {
   EntityPropertiesDialog,
   TaskConfigDialog,
   ServerOverview,
+  SupportBundleDialog,
+  FeedbackDialog,
   UserManager,
   AuthenticationDisabledWarningBanner,
   WarehouseRenameDialog,

--- a/src/stores/visual.ts
+++ b/src/stores/visual.ts
@@ -123,6 +123,7 @@ export const useVisualStore = defineStore(
 
     const serverInfo = reactive<ServerInfo>({
       version: '0.0.0',
+      'lakekeeper-version': '0.0.0',
       bootstrapped: true,
       'server-id': '00000000-0000-0000-0000-000000000000',
       'default-project-id': '00000000-0000-0000-0000-000000000000',


### PR DESCRIPTION
## Summary

- Revamps the **Server Overview** page: two-column Server Information + Console layout, edition-gated version row, and a new User Surveys row in UI Configuration.
- Adds a reusable **SupportBundleDialog** (Copy + Download JSON) with an "Export" button on the page and an extra item under the AppBar help menu — label adapts per edition ("Export for GitHub" in OSS, "Export for Support" in Enterprise).
- Adds a **FeedbackDialog** (OSS only) launched from a new icon at the right of the AppBar — 1-10 rating, discovery source select with "Other" fallback, improvements textarea (max 2000 chars). Pre-fills a mailto draft to `info@vakamo.com`.
- Regenerates the management OpenAPI types to add `ConsoleInfo` and `lakekeeper-(enterprise-)version` fields that the page now reads.

## Test plan

- [ ] `just reviewable` passes locally
- [ ] OSS console (edition=oss): Server Overview shows "Lakekeeper Version"; feedback icon visible at right of AppBar; Export button label reads "Export for GitHub"
- [ ] Enterprise console (edition=enterprise): Server Overview shows "Enterprise Version"; no feedback icon; Export label reads "Export for Support"
- [ ] Export dialog: Copy + Download work, JSON contains serverInfo + uiConfig and no tokens
- [ ] Feedback dialog: Send is disabled until Discovery + Improvements are filled; "Other" reveals a required specify field; mailto draft opens with the plain-text body

BEGIN_COMMIT_OVERRIDE
feat(ui): two-column Server Information + Console layout in ServerOverview
feat(ui): edition-gated Lakekeeper / Enterprise Version row
feat(ui): User Surveys row in UI Configuration
feat(ui): SupportBundleDialog with Copy and Download JSON actions
feat(ui): FeedbackDialog (OSS) wired to AppBar with mailto draft
feat(ui): Export item added to AppBar help menu
chore(ui): regenerate management OpenAPI with ConsoleInfo type and lakekeeper-(enterprise-)version fields
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support bundle export feature with copy-to-clipboard and download actions
  * Feedback collection dialog for OSS editions including ratings and improvement suggestions
  * Server overview now displays console information alongside server details
  * User surveys configuration visibility in UI configuration settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/console-components/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->