### PR TITLE
fix: set Renovate semanticCommitType to fix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "schedule": ["before 9am on monday"],
+  "semanticCommitType": "fix",
   "packageRules": [
     {
       "groupName": "eslint",


### PR DESCRIPTION
## Summary

By default Renovate emits `chore(deps): ...` commit titles, which release-please ignores. Setting `semanticCommitType: "fix"` causes Renovate to emit `fix(deps): ...` titles, so each dep-bump merge produces a patch release.

This PR also acts as the trigger that flushes the already-merged dep updates (#152, #155, #164, #168) into the next release.

BEGIN_COMMIT_OVERRIDE
fix(ci): set Renovate semanticCommitType to fix so dep PRs trigger releases
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)