### PR TITLE
fix: drop obsolete baseUrl and ignoreDeprecations from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": "./src",
     "paths": {
-      "@/*": ["*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.vue"],


### PR DESCRIPTION
## What

Drop the obsolete `baseUrl` and `ignoreDeprecations` from `tsconfig.json`, and make the `@/*` path tsconfig-relative (`*` → `./src/*`).

## Why

With `moduleResolution: "bundler"` (TS 5.0+), `baseUrl` is no longer required for `paths` — they resolve relative to the tsconfig location. `ignoreDeprecations: "6.0"` only suppressed errors for legacy options (none of which are used here), so it was a no-op. No behavior change; `vue-tsc --noEmit` passes clean.

BEGIN_COMMIT_OVERRIDE
fix(ui): drop obsolete baseUrl and ignoreDeprecations from tsconfig
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript module path configuration for improved import resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lakekeeper/console-components/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->