### PR TITLE
feat: single-page role detail (details, members, owners) + shared principal search

### DIFF
--- a/src/components/PermissionAssignDialog.vue
+++ b/src/components/PermissionAssignDialog.vue
@@ -264,7 +264,9 @@ const objRelation = computed(() => {
   }
   throw new Error('Invalid relation type');
 });
-const roleRelations: RoleRelation[] = ['assignee', 'ownership'];
+// 'assignee' (role membership) is managed in the role's Members tab, so the
+// Permissions tab only grants 'ownership' (who can administer the role).
+const roleRelations: RoleRelation[] = ['ownership'];
 const serverRelation: ServerRelation[] = ['admin', 'operator'];
 const toWrite = reactive<any[]>([]);
 const toDelete = reactive<any[]>([]);

--- a/src/components/PermissionManager.vue
+++ b/src/components/PermissionManager.vue
@@ -414,6 +414,10 @@ async function init() {
   const assignments = await fetchAssignments();
 
   for (const permission of assignments) {
+    // Role membership ('assignee') is shown/managed in the Members tab — keep the
+    // Permissions tab to 'ownership' only so the two don't overlap.
+    if (props.relationType === RelationType.Role && permission.type === 'assignee') continue;
+
     const searchUser: any = permission;
 
     if (searchUser.user) {

--- a/src/components/PrincipalSearch.vue
+++ b/src/components/PrincipalSearch.vue
@@ -1,0 +1,259 @@
+<template>
+  <div>
+    <v-btn-toggle
+      :model-value="type"
+      mandatory
+      density="compact"
+      variant="outlined"
+      class="mb-3"
+      @update:model-value="onTypeChange">
+      <v-btn value="user" size="small" prepend-icon="mdi-account">User</v-btn>
+      <v-btn value="role" size="small" prepend-icon="mdi-account-group">Role</v-btn>
+    </v-btn-toggle>
+
+    <!-- Project selector for role search (roles are project-scoped) -->
+    <v-select
+      v-if="type === 'role' && userProjects.length > 1"
+      v-model="selectedProject"
+      :items="userProjects"
+      item-title="project-name"
+      item-value="project-id"
+      label="Project"
+      density="compact"
+      variant="outlined"
+      hide-details
+      class="mb-3"
+      :loading="loadingProjects"
+      prepend-inner-icon="mdi-folder-account"
+      @update:model-value="rerun">
+      <template #item="{ props: ip, item }">
+        <v-list-item v-bind="ip">
+          <template #title>
+            {{ item.raw['project-name'] }} ({{ item.raw['project-id'] }})
+            <span
+              v-if="item.raw['project-id'] === currentProjectId"
+              class="text-primary text-caption">
+              · active
+            </span>
+          </template>
+        </v-list-item>
+      </template>
+      <template #selection="{ item }">
+        {{ item.raw['project-name'] }} ({{ item.raw['project-id'] }})
+      </template>
+    </v-select>
+
+    <div class="d-flex align-center">
+      <v-spacer></v-spacer>
+      <v-switch
+        v-model="byId"
+        label="By ID"
+        density="compact"
+        hide-details
+        inset
+        color="primary"></v-switch>
+    </div>
+
+    <v-autocomplete
+      v-if="!byId"
+      :model-value="modelValue"
+      :items="candidates"
+      :loading="searching"
+      :search="search"
+      item-title="title"
+      item-value="id"
+      return-object
+      label="Search by name"
+      placeholder="Type to search"
+      no-filter
+      density="compact"
+      variant="outlined"
+      hide-details
+      @update:search="onSearch"
+      @update:model-value="$emit('update:modelValue', $event)"></v-autocomplete>
+
+    <v-text-field
+      v-else
+      v-model="idInput"
+      label="Paste an identifier"
+      density="compact"
+      variant="outlined"
+      hide-details
+      clearable
+      :loading="searching"
+      @update:model-value="onIdSearch"></v-text-field>
+
+    <div v-if="modelValue" class="text-caption text-medium-emphasis mt-2">
+      Selected:
+      <strong>{{ modelValue.title }}</strong>
+      · {{ modelValue.id }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, reactive, ref, computed, watch } from 'vue';
+import { useFunctions } from '../plugins/functions';
+import { useVisualStore } from '../stores/visual';
+
+export interface SelectedPrincipal {
+  id: string;
+  title: string;
+  type: 'user' | 'role';
+}
+
+const props = defineProps<{
+  modelValue: SelectedPrincipal | null;
+  /** A role id to exclude from role results (e.g. the role being edited). */
+  excludeRoleId?: string;
+}>();
+const emit = defineEmits<{
+  (e: 'update:modelValue', v: SelectedPrincipal | null): void;
+}>();
+
+const functions = useFunctions();
+const visual = useVisualStore();
+
+const type = ref<'user' | 'role'>('user');
+const byId = ref(false);
+const idInput = ref('');
+const search = ref('');
+const searching = ref(false);
+const candidates = ref<SelectedPrincipal[]>([]);
+
+// Project selector (role search only)
+const userProjects = reactive<any[]>([]);
+const loadingProjects = ref(false);
+const selectedProject = ref<string | null>(null);
+const currentProjectId = computed(() => visual.projectSelected['project-id'] || null);
+
+async function loadProjects() {
+  if (userProjects.length) return;
+  loadingProjects.value = true;
+  try {
+    const projects = await functions.loadProjectList();
+    userProjects.splice(0, userProjects.length, ...projects);
+    if (!selectedProject.value) {
+      selectedProject.value =
+        projects.length === 1 ? projects[0]['project-id'] : currentProjectId.value;
+    }
+  } catch {
+    /* surfaced by the functions plugin */
+  } finally {
+    loadingProjects.value = false;
+  }
+}
+
+function onTypeChange(v: 'user' | 'role') {
+  type.value = v;
+  emit('update:modelValue', null);
+  candidates.value = [];
+  search.value = '';
+  idInput.value = '';
+  if (v === 'role') loadProjects();
+}
+
+function looksLikeId(s: string): boolean {
+  return /~/.test(s) || /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(s) || /^[A-Za-z0-9_-]{16,}$/.test(s);
+}
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+function onSearch(q: string) {
+  search.value = q;
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(() => runSearch(q), 250);
+}
+function rerun() {
+  runSearch(search.value);
+}
+
+async function runSearch(q: string) {
+  if (!q) {
+    candidates.value = [];
+    return;
+  }
+  searching.value = true;
+  try {
+    let list: SelectedPrincipal[] = [];
+    if (type.value === 'user') {
+      const users = await functions.searchUser(q);
+      list = (users ?? []).map((u: any) => ({
+        id: u.id,
+        type: 'user' as const,
+        title: `${u.name || u['preferred_username'] || u.id}${u.email ? ` · ${u.email}` : ''}`,
+      }));
+    } else {
+      const req: any = { search: q };
+      if (selectedProject.value) req['project-id'] = selectedProject.value;
+      const roles = await functions.searchRole(req);
+      list = (roles ?? [])
+        .filter((r: any) => r.id !== props.excludeRoleId)
+        .map((r: any) => ({ id: r.id, type: 'role' as const, title: r.name || r.ident || r.id }));
+    }
+    if (looksLikeId(q) && !list.some((c) => c.id === q)) {
+      const resolved = await resolveById(q);
+      if (resolved) list.unshift(resolved);
+    }
+    candidates.value = list;
+  } catch {
+    candidates.value = [];
+  } finally {
+    searching.value = false;
+  }
+}
+
+let idTimer: ReturnType<typeof setTimeout> | null = null;
+function onIdSearch(v: string) {
+  idInput.value = v;
+  if (idTimer) clearTimeout(idTimer);
+  idTimer = setTimeout(async () => {
+    if (!v) {
+      emit('update:modelValue', null);
+      return;
+    }
+    searching.value = true;
+    try {
+      const resolved = await resolveById(v);
+      emit('update:modelValue', resolved);
+    } finally {
+      searching.value = false;
+    }
+  }, 300);
+}
+
+async function resolveById(id: string): Promise<SelectedPrincipal | null> {
+  try {
+    if (type.value === 'user') {
+      const u: any = await functions.getUser(id);
+      if (u?.id) {
+        return {
+          id: u.id,
+          type: 'user',
+          title: `${u.name || u['preferred_username'] || u.id}${u.email ? ` · ${u.email}` : ''}`,
+        };
+      }
+    } else {
+      const r: any = await functions.getRoleMetadata(id);
+      if (r?.id && r.id !== props.excludeRoleId) {
+        return { id: r.id, type: 'role', title: r.name || r.id };
+      }
+    }
+  } catch {
+    /* not a resolvable id */
+  }
+  return null;
+}
+
+watch(byId, () => {
+  emit('update:modelValue', null);
+  idInput.value = '';
+});
+
+onMounted(() => {
+  if (type.value === 'role') loadProjects();
+});
+onUnmounted(() => {
+  if (timer) clearTimeout(timer);
+  if (idTimer) clearTimeout(idTimer);
+});
+</script>

--- a/src/components/RoleDetail.vue
+++ b/src/components/RoleDetail.vue
@@ -1,0 +1,75 @@
+<template>
+  <div>
+    <!-- Breadcrumb keeps the Roles › <role> context (and back navigation) -->
+    <v-breadcrumbs
+      class="px-0 mt-2"
+      :items="[
+        { title: 'Roles', to: '/identities' },
+        { title: roleName || '—', disabled: true },
+      ]">
+      <template #prepend>
+        <v-icon size="small" color="info">mdi-account-box-multiple-outline</v-icon>
+      </template>
+    </v-breadcrumbs>
+
+    <RoleOverviewEdit :role-id="roleId" class="mb-4" />
+    <RoleMembers :role-id="roleId" :can-edit="canEdit" class="mb-4" />
+    <RoleOwners :role-id="roleId" :can-edit="canEdit" class="mb-4" />
+
+    <!-- Roles this role is a member of (inherits from) -->
+    <v-card variant="outlined" class="mt-4">
+      <v-toolbar color="transparent" density="compact" flat>
+        <v-toolbar-title class="text-subtitle-1">
+          <v-icon class="mr-2">mdi-account-arrow-up</v-icon>
+          Member of
+          <v-chip size="x-small" variant="tonal" class="ml-2">{{ memberOf.length }}</v-chip>
+        </v-toolbar-title>
+      </v-toolbar>
+      <v-divider></v-divider>
+      <v-card-text>
+        <div v-if="memberOf.length" class="d-flex flex-wrap" style="gap: 6px">
+          <v-chip
+            v-for="r in memberOf"
+            :key="r.id"
+            size="small"
+            variant="tonal"
+            prepend-icon="mdi-account-group">
+            {{ r.name || r.ident }}
+          </v-chip>
+        </div>
+        <div v-else class="text-medium-emphasis">This role is not a member of any other role.</div>
+      </v-card-text>
+    </v-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+import { useFunctions } from '../plugins/functions';
+import type { RoleMembership } from '../gen/management/types.gen';
+import RoleOverviewEdit from './RoleOverviewEdit.vue';
+import RoleMembers from './RoleMembers.vue';
+import RoleOwners from './RoleOwners.vue';
+
+const props = defineProps<{ roleId: string; canEdit?: boolean }>();
+
+const functions = useFunctions();
+const roleName = ref('');
+const memberOf = ref<RoleMembership[]>([]);
+
+async function load() {
+  try {
+    const [meta, mo] = await Promise.all([
+      functions.getRoleMetadata(props.roleId).catch(() => null),
+      functions.listRoleMemberOf(props.roleId).catch(() => ({ roles: [] })),
+    ]);
+    roleName.value = (meta as any)?.name ?? '';
+    memberOf.value = ((mo as any)?.roles ?? []) as RoleMembership[];
+  } catch {
+    /* surfaced by the functions plugin */
+  }
+}
+
+onMounted(load);
+watch(() => props.roleId, load);
+</script>

--- a/src/components/RoleManager.vue
+++ b/src/components/RoleManager.vue
@@ -101,6 +101,11 @@ const visual = useVisualStore();
 const router = useRouter();
 const notify = true;
 
+// In `inline` mode (e.g. the Identities page) row clicks emit `select` so the
+// detail can render in-place instead of navigating to /roles/:id.
+const props = defineProps<{ inline?: boolean }>();
+const emit = defineEmits<{ (e: 'select', id: string): void }>();
+
 interface ExtendedRole extends Role {
   can_delete?: boolean;
 }
@@ -167,6 +172,10 @@ watch(
 );
 
 function getRole(id: string) {
+  if (props.inline) {
+    emit('select', id);
+    return;
+  }
   router.push(`/roles/${id}`);
 }
 

--- a/src/components/RoleMembers.vue
+++ b/src/components/RoleMembers.vue
@@ -202,6 +202,12 @@ function onSearch(q: string) {
   if (searchTimer) clearTimeout(searchTimer);
   searchTimer = setTimeout(() => runSearch(q), 250);
 }
+// Treat a query as an identifier (so we also try a direct lookup) when it looks
+// like a UUID or carries an idp prefix (e.g. `oidc~…`, `kubernetes~…`).
+function looksLikeId(s: string): boolean {
+  return /~/.test(s) || /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(s) || /^[A-Za-z0-9_-]{16,}$/.test(s);
+}
+
 async function runSearch(q: string) {
   if (!q) {
     addCandidates.value = [];
@@ -209,18 +215,44 @@ async function runSearch(q: string) {
   }
   searching.value = true;
   try {
+    let candidates: { id: string; title: string }[] = [];
     if (addType.value === 'user') {
       const users = await functions.searchUser(q);
-      addCandidates.value = (users ?? []).map((u: any) => ({
+      candidates = (users ?? []).map((u: any) => ({
         id: u.id,
         title: `${u.name || u['preferred_username'] || u.id}${u.email ? ` · ${u.email}` : ''}`,
       }));
     } else {
       const roles = await functions.searchRole(q);
-      addCandidates.value = (roles ?? [])
+      candidates = (roles ?? [])
         .filter((r: any) => r.id !== props.roleId)
         .map((r: any) => ({ id: r.id, title: r.name || r.ident || r.id }));
     }
+
+    // Also resolve by identifier (mirrors the Permissions dialog "Search by ID")
+    // so principals without a searchable name — service principals, OIDC/k8s
+    // subjects, or a known role id — are still findable.
+    if (looksLikeId(q) && !candidates.some((c) => c.id === q)) {
+      try {
+        if (addType.value === 'user') {
+          const u: any = await functions.getUser(q);
+          if (u?.id) {
+            candidates.unshift({
+              id: u.id,
+              title: `${u.name || u['preferred_username'] || u.id}${u.email ? ` · ${u.email}` : ''}`,
+            });
+          }
+        } else {
+          const r: any = await functions.getRoleMetadata(q);
+          if (r?.id && r.id !== props.roleId) {
+            candidates.unshift({ id: r.id, title: r.name || r.id });
+          }
+        }
+      } catch {
+        /* not a resolvable id — name results (if any) still stand */
+      }
+    }
+    addCandidates.value = candidates;
   } catch {
     addCandidates.value = [];
   } finally {

--- a/src/components/RoleOverviewEdit.vue
+++ b/src/components/RoleOverviewEdit.vue
@@ -1,31 +1,19 @@
 <template>
-  <v-card>
-    <v-card-item>
-      <template #prepend>
-        <v-avatar color="info" variant="tonal" size="44">
-          <v-icon size="24">mdi-account-box-multiple-outline</v-icon>
-        </v-avatar>
-      </template>
-      <template #append>
-        <v-btn
-          color="info"
-          size="small"
-          to="/roles"
-          variant="outlined"
-          prepend-icon="mdi-arrow-left"
-          class="mr-2">
-          Back
-        </v-btn>
-        <RoleDialog
-          v-if="role.name && canUpdate"
-          :action-type="'edit'"
-          :role="role"
-          @role-input="editRole" />
-      </template>
-      <v-card-title class="text-h5">{{ role.name || '—' }}</v-card-title>
-    </v-card-item>
+  <v-card variant="outlined">
+    <v-toolbar color="transparent" density="compact" flat>
+      <v-toolbar-title class="text-subtitle-1">
+        <v-icon class="mr-2" color="primary">mdi-card-account-details-outline</v-icon>
+        Details
+      </v-toolbar-title>
+      <v-spacer></v-spacer>
+      <RoleDialog
+        v-if="role.name && canUpdate"
+        :action-type="'edit'"
+        :role="role"
+        @role-input="editRole" />
+    </v-toolbar>
 
-    <v-divider class="mx-4"></v-divider>
+    <v-divider></v-divider>
 
     <v-card-text v-if="role.id">
       <v-row dense>

--- a/src/components/RoleOwners.vue
+++ b/src/components/RoleOwners.vue
@@ -2,13 +2,13 @@
   <v-card variant="outlined">
     <v-toolbar color="transparent" density="compact" flat>
       <v-toolbar-title class="text-subtitle-1">
-        <v-icon class="mr-2" color="primary">mdi-account-multiple</v-icon>
-        Members
-        <v-chip size="x-small" variant="tonal" class="ml-2">{{ members.length }}</v-chip>
+        <v-icon class="mr-2" color="primary">mdi-shield-account</v-icon>
+        Owners
+        <v-chip size="x-small" variant="tonal" class="ml-2">{{ owners.length }}</v-chip>
       </v-toolbar-title>
       <v-spacer></v-spacer>
       <v-btn-toggle
-        v-model="memberFilter"
+        v-model="ownerFilter"
         mandatory
         density="compact"
         variant="outlined"
@@ -18,32 +18,20 @@
         <v-btn value="role" size="small" prepend-icon="mdi-account-group">Roles</v-btn>
       </v-btn-toggle>
       <v-btn
-        v-if="canEdit && selected.length"
-        color="error"
-        variant="tonal"
-        size="small"
-        prepend-icon="mdi-account-remove"
-        class="mr-2"
-        @click="requestRemove(selectedItems)">
-        Remove ({{ selected.length }})
-      </v-btn>
-      <v-btn
         v-if="canEdit"
         color="primary"
         variant="tonal"
         size="small"
         prepend-icon="mdi-plus"
         @click="openAdd">
-        Add member
+        Add owner
       </v-btn>
     </v-toolbar>
     <v-divider></v-divider>
     <v-data-table
-      v-model="selected"
-      :headers="memberHeaders"
-      :items="filteredMembers"
+      :headers="ownerHeaders"
+      :items="filteredOwners"
       :loading="loading"
-      :show-select="canEdit"
       density="compact"
       item-value="id">
       <template #item.type="{ item }">
@@ -54,11 +42,8 @@
           {{ item.type }}
         </v-chip>
       </template>
-      <template #item.name="{ item }">{{ item.name || item.ident || item.id }}</template>
-      <template #item.detail="{ item }">
-        <span class="text-caption text-medium-emphasis">
-          {{ item.type === 'user' ? item.email || item.id : item.ident }}
-        </span>
+      <template #item.name="{ item }">
+        {{ item.name || item.id }}
         <span
           v-if="item.type === 'role' && item.projectId && item.projectId !== currentProjectId"
           class="text-caption text-grey">
@@ -80,17 +65,17 @@
           icon="mdi-close"
           size="x-small"
           variant="text"
-          @click="requestRemove([item])"></v-btn>
+          @click="requestRemove(item)"></v-btn>
       </template>
       <template #no-data>
-        <div class="text-center pa-4 text-medium-emphasis">No members</div>
+        <div class="text-center pa-4 text-medium-emphasis">No owners</div>
       </template>
     </v-data-table>
 
-    <!-- Add member dialog -->
+    <!-- Add owner dialog -->
     <v-dialog v-model="addOpen" max-width="1000">
       <v-card>
-        <v-card-title>Add member</v-card-title>
+        <v-card-title>Add owner</v-card-title>
         <v-card-text>
           <PrincipalSearch v-model="addSelected" :exclude-role-id="roleId" />
         </v-card-text>
@@ -108,21 +93,13 @@
       </v-card>
     </v-dialog>
 
-    <!-- Remove member(s) confirm dialog -->
-    <v-dialog v-model="removeConfirm.open" max-width="480">
+    <!-- Remove owner confirm -->
+    <v-dialog v-model="removeConfirm.open" max-width="460">
       <v-card>
-        <v-card-title class="text-subtitle-1 font-weight-medium">
-          Remove {{ removeConfirm.items.length }} member{{
-            removeConfirm.items.length === 1 ? '' : 's'
-          }}?
-        </v-card-title>
+        <v-card-title class="text-subtitle-1 font-weight-medium">Remove owner?</v-card-title>
         <v-card-text class="text-body-2">
-          They will lose the permissions inherited from this role.
-          <ul class="mt-2 ml-4">
-            <li v-for="it in removeConfirm.items" :key="it.id">
-              {{ it.name || it.ident || it.id }}
-            </li>
-          </ul>
+          {{ removeConfirm.item?.name || removeConfirm.item?.id }} will no longer be able to
+          administer this role.
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
@@ -140,7 +117,7 @@
 import { computed, onMounted, reactive, ref, watch } from 'vue';
 import { useFunctions } from '../plugins/functions';
 import { useVisualStore } from '../stores/visual';
-import type { RoleMember } from '../gen/management/types.gen';
+import type { RoleAssignment } from '../gen/management/types.gen';
 import PrincipalSearch, { type SelectedPrincipal } from './PrincipalSearch.vue';
 
 const props = defineProps<{
@@ -152,49 +129,43 @@ const functions = useFunctions();
 const visual = useVisualStore();
 const currentProjectId = computed(() => visual.projectSelected['project-id'] || '');
 
+interface OwnerRow {
+  id: string;
+  type: 'user' | 'role';
+  name?: string;
+  projectId?: string;
+}
+
 const loading = ref(false);
-const members = ref<
-  Array<
-    RoleMember & { id: string; name?: string; ident?: string; email?: string; projectId?: string }
-  >
->([]);
-
-// Selection + type filter + remove-confirm state
-const selected = ref<string[]>([]);
-const memberFilter = ref<'all' | 'user' | 'role'>('all');
-const removing = ref(false);
-const removeConfirm = reactive<{ open: boolean; items: any[] }>({ open: false, items: [] });
-
-const filteredMembers = computed(() =>
-  memberFilter.value === 'all'
-    ? members.value
-    : members.value.filter((m) => m.type === memberFilter.value),
+const owners = ref<OwnerRow[]>([]);
+const ownerFilter = ref<'all' | 'user' | 'role'>('all');
+const filteredOwners = computed(() =>
+  ownerFilter.value === 'all'
+    ? owners.value
+    : owners.value.filter((o) => o.type === ownerFilter.value),
 );
-const selectedItems = computed(() => members.value.filter((m) => selected.value.includes(m.id)));
-
-const memberHeaders = [
+const ownerHeaders = [
   { title: 'Type', key: 'type', sortable: false, width: 90 },
   { title: 'Name', key: 'name', sortable: false },
-  { title: 'Identifier', key: 'detail', sortable: false },
   { title: '', key: 'actions', sortable: false, align: 'end' as const, width: 56 },
 ];
 
 async function load() {
   loading.value = true;
   try {
-    const m = await functions.listRoleMembers(props.roleId);
-    const list = (m?.members ?? []) as any[];
-    // RoleMembership carries no project-id, so resolve it for role members
-    // (lets the list flag nested roles from another project).
-    await Promise.all(
-      list
-        .filter((x) => x.type === 'role')
-        .map(async (x) => {
-          const meta: any = await functions.getRoleMetadata(x.id).catch(() => null);
-          x.projectId = meta?.['project-id'];
-        }),
-    );
-    members.value = list as any;
+    const assignments = (await functions.getRoleAssignmentsById(props.roleId)) as RoleAssignment[];
+    const ownerships = (assignments ?? []).filter((a: any) => a.type === 'ownership');
+    const rows: OwnerRow[] = [];
+    for (const a of ownerships as any[]) {
+      if (a.user) {
+        const u: any = await functions.getUser(a.user).catch(() => null);
+        rows.push({ id: a.user, type: 'user', name: u?.name || u?.['preferred_username'] });
+      } else if (a.role) {
+        const r: any = await functions.getRoleMetadata(a.role).catch(() => null);
+        rows.push({ id: a.role, type: 'role', name: r?.name, projectId: r?.['project-id'] });
+      }
+    }
+    owners.value = rows;
   } catch {
     /* surfaced by the functions plugin */
   } finally {
@@ -202,29 +173,37 @@ async function load() {
   }
 }
 
-function requestRemove(items: Array<{ id: string; type: 'user' | 'role'; name?: string }>) {
-  if (!items.length) return;
-  removeConfirm.items = [...items];
+// --- Remove ---------------------------------------------------------------
+const removing = ref(false);
+const removeConfirm = reactive<{ open: boolean; item: OwnerRow | null }>({
+  open: false,
+  item: null,
+});
+function requestRemove(item: OwnerRow) {
+  removeConfirm.item = item;
   removeConfirm.open = true;
 }
-
 async function confirmRemove() {
+  const item = removeConfirm.item;
+  if (!item) return;
   removing.value = true;
   try {
-    for (const it of removeConfirm.items) {
-      await functions.removeRoleMember(props.roleId, it.type, it.id, false);
-    }
-    selected.value = [];
+    const del: any[] = [
+      item.type === 'user'
+        ? { user: item.id, type: 'ownership' }
+        : { role: item.id, type: 'ownership' },
+    ];
+    await functions.updateRoleAssignmentsById(props.roleId, del, [], true);
     await load();
   } catch {
-    /* surfaced by the functions plugin */
+    /* surfaced */
   } finally {
     removing.value = false;
     removeConfirm.open = false;
   }
 }
 
-// --- Add member -------------------------------------------------------------
+// --- Add ------------------------------------------------------------------
 const addOpen = ref(false);
 const addSelected = ref<SelectedPrincipal | null>(null);
 const adding = ref(false);
@@ -238,11 +217,12 @@ async function confirmAdd() {
   if (!addSelected.value) return;
   adding.value = true;
   try {
-    await functions.addRoleMembers(
-      props.roleId,
-      [{ id: addSelected.value.id, type: addSelected.value.type }],
-      true,
-    );
+    const writes: any[] = [
+      addSelected.value.type === 'user'
+        ? { user: addSelected.value.id, type: 'ownership' }
+        : { role: addSelected.value.id, type: 'ownership' },
+    ];
+    await functions.updateRoleAssignmentsById(props.roleId, [], writes, true);
     addOpen.value = false;
     await load();
   } catch {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import NamespaceAddDialog from './components/NamespaceAddDialog.vue';
 import RoleDialog from './components/RoleDialog.vue';
 import RoleManager from './components/RoleManager.vue';
 import RoleMembers from './components/RoleMembers.vue';
+import RoleOwners from './components/RoleOwners.vue';
+import RoleDetail from './components/RoleDetail.vue';
 import RoleOverviewEdit from './components/RoleOverviewEdit.vue';
 import ProjectNameAddOrEditDialog from './components/ProjectNameAddOrEditDialog.vue';
 import AuthenticationDisabledWarningBanner from './components/AuthenticationDisabledWarningBanner.vue';
@@ -95,6 +97,8 @@ export {
   RoleDialog,
   RoleManager,
   RoleMembers,
+  RoleOwners,
+  RoleDetail,
   RoleOverviewEdit,
   AppBar,
   WarningBanner,
@@ -280,6 +284,8 @@ const components = {
   RoleDialog,
   RoleManager,
   RoleMembers,
+  RoleOwners,
+  RoleDetail,
   RoleOverviewEdit,
   AppBar,
   WarningBanner,


### PR DESCRIPTION
Redesigns the role page into a single, cohesive view and adds owner management.

- **RoleDetail**: one page — breadcrumb (Roles / name), Details, Members, Owners, and "Member of", all consistent outlined cards.
- **RoleOwners**: manage the role's `ownership` assignments (add/remove + confirm + type filter).
- **PrincipalSearch**: shared user/role picker — type toggle, project selector for roles, name search + by-id (parity with project grants).
- **RoleMembers**: bulk remove + per-row confirm, type filter, external-project role indicator; uses PrincipalSearch.
- **RoleManager**: `inline` mode emits `select` (lets the Identities page show detail in-tab).
- **PermissionManager / role**: manages only `ownership` (membership lives in the Members section).

BEGIN_COMMIT_OVERRIDE
fix(ui): role Permissions manages ownership only, not membership
feat(ui): id-aware member search
feat(ui): single-page role detail with members, owners, and shared principal search
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Role Owners management—assign and remove owners with filtering by user/role type.
  * Introduced comprehensive Role Detail page displaying overview, members, and owners sections.
  * Enhanced Role Members with filtering capabilities and batch removal via confirmation dialog.
  * Added Principal Search component for user/role selection across the application.

* **Bug Fixes**
  * Clarified separation between role membership and ownership management.
  * Improved external project role visibility with project ID indicators and copy actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->